### PR TITLE
Add documentation about external load balancer

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -71,6 +71,12 @@ Each Kubernetes cluster provisioned through PKS deploys the following VMs:
 </tr>
 </table>
 
+##<a id='prereqs'></a> Prerequisites
+
+* An external load balancer is required to access the PKS-API.
+
+* An external load balancer is required to access each created cluster.
+
 ##<a id='install'></a> Step 1: Install PKS
 
 Perform the following steps to install PKS:
@@ -221,6 +227,10 @@ Perform the following steps to retrieve the PKS API endpoint:
 1. Click the PKS tile.
 1. Click the **Status** tab and locate the IP address of the PKS API endpoint. This is the endpoint that developers use to create and manage clusters. See [Using PKS](using.html) for more information.
 
+##<a id='loadbalancer-pks-api'></a> Step 6: Configuring External Load Balancer
+
+Configure the external load balancer set up previously (should resolve to domain name used during cerificate generation in [above step](installing.html#pks-api) )
+to forward traffic to PKS API endpoint.
 
 
 

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -20,7 +20,9 @@ To deploy application workloads to a Kubernetes cluster, developers use `kubectl
 
 ##<a id='prereqs'></a> Prerequisites
 
-To perform the procedures in this topic, you must have a Pivotal Cloud Foundry (PCF) deployment with Ops Manager and PKS installed, but not Pivotal Application Service (PAS). This procedure only works if PAS is not installed.
+* To perform the procedures in this topic, you must have a Pivotal Cloud Foundry (PCF) deployment with Ops Manager and PKS installed, but not Pivotal Application Service (PAS). This procedure only works if PAS is not installed.
+
+* An external load balancer is required to be configured before cluster creation.
 
 ##<a id='create-cluster'></a> Create Cluster
 
@@ -29,12 +31,9 @@ To create a cluster, perform the following steps:
 1. Choose a unique name for your cluster and set it as an environment variable named `CLUSTER_NAME`. For example:
   <pre class="terminal">$ export CLUSTER\_NAME="my-cluster"</pre>
 
-1. Retrieve the IP address of your Kubernetes master host and set it as an environment variable named `KUBERNETES_SERVICE_HOST`. For example:
+1. Retrieve the IP address of the external load balancer set up previously and set it as an environment variable named `KUBERNETES_SERVICE_HOST`. For example:
   <pre class="terminal">$ export KUBERNETES\_SERVICE\_HOST="192.0.2.0"</pre>
-
-1. Retrieve the IP addresses of your Kubernetes worker nodes and set them as an environment variable named `WORKLOAD_ADDRESS`. For example:
-  <pre class="terminal">$ export WORKLOAD\_ADDRESS="192.0.2.1,192.0.2.2,192.0.2.3"</pre>
-
+  
 1. Choose either attribute-based access control (ABAC) or role-based access control (RBAC) for your authorization mode. Set an environment variable named `AUTHORIZATION_MODE` to `abac` or `rbac`. For example:
   <pre class="terminal">$ export AUTHORIZATION\_MODE="abac"</pre>
   For more information about authorization modes, see the [Kubernetes documentation](https://kubernetes.io/docs/admin/authorization/#authorization-modules).
@@ -47,13 +46,15 @@ To create a cluster, perform the following steps:
   --header 'Content-Type: application/json' \
   --header 'Accept: application/json;charset=UTF-8' \
   -d '{"name": "$CLUSTER\_NAME","parameters": \
-  {"kubernetes\_master\_host": \
-  "$KUBERNETES\_SERVICE\_HOST","worker_haproxy\_ip\_addresses": \
-  "$WORKLOAD\_ADDRESS:-", "authorization\_mode": \
-  "$AUTHORIZATION\_MODE" },"plan\_id": ""}' \
+  {"kubernetes\_master\_host": "$KUBERNETES\_SERVICE\_HOST", \
+  "kubernetes\_master\_port": "8843", \
+   "authorization\_mode": "$AUTHORIZATION\_MODE" }, \
+   "plan\_id": ""}' \
   https://$PKS\_API\_ENDPOINT:9021/v1/clusters/</pre>
+  
+2. Ensure your operator has configured the previously set up load balancer to point to the newly created cluster's master vm.
 
-2. Bind a user to the newly created cluster with the following command and export the output as an environment variable named `CREDENTIALS`:
+3. Bind a user to the newly created cluster with the following command and export the output as an environment variable named `CREDENTIALS`:
   <pre class="terminal">$ export CREDENTIALS="$(curl -k -s -X POST \
   -d "{}" \
   https://$PKS\_API\_ENDPOINT:9021/v1/clusters/$CLUSTER\_NAME/binds)"


### PR DESCRIPTION
* An external load balancer is required to be configured for the pks
api.
* An external load balancer is required to be confifured for each
cluster created to access the kubernetes master port.

[#152658230]

Signed-off-by: Neil Hickey <nhickey@pivotal.io>