### PR TITLE
updated release notes

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -3,6 +3,30 @@ title: PKS Release Notes
 owner: PKS
 ---
 
+## v0.5.0-18 (Dev Release)
+
+**Release Date**: Nov 20, 2017
+
+### Features
+
+* External routing is now an option for PKS. Next release will deprecate the 'Proxy' routing mode. Prior to this, users had to provide static IPs for the kubernetes master and worker HA proxies. Now, choosing external routing mode will allow users to create clusters via an IP not specified in the cloud config. This could be a load balancer given to the user by admins, or self generated via a load-balancer-as-a-service product in the org. 
+* GCP support is also enabled in this version. See known issues for details.
+* Cluster data in the PKS API will persist after the PKS API is restarted.
+* Workloads with persistence can be deployed on clusters created with PKS on vSphere and GCP.
+* Users can delete clusters using the PKS API.
+* When listing clusters, the PKS API will display clusters while they are deleting.
+* The PKS tile configuration allows users to define the default cluster configuration that is deployed with the PKS API.
+
+## Bugs
+
+* PKS Tile configuration for ETCD VM Type was located on the wrong page, it has now been moved alongisde other plan configuration fields in the "Plans" tab.
+
+## Known Issues
+
+* PKS tiles deployed on GCP must go through an extra step in this version to set up the cloud config such that the GCP service account used by PKS is specified for each VM. Documentation has been updated with scripts to help facilitate this otherwise tedious action.
+* Users will still have to update the runtime config in bosh after applying changes, so that cluster creation can occur. This is outlined in documentation.
+
+
 ## v0.5.0-1 (Dev Release)
 
 **Release Date**: Nov 13, 2017


### PR DESCRIPTION
I noticed that release notes have a tab version at the top that say 0.8 - can we update that to match the actual dev releases until we have 0.8.0?