### PR TITLE
updated some preamble to step 5/6

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -221,6 +221,8 @@ If you are deploying on GCP, you must also update the cloud config for all `vm_t
 	<pre class="terminal">$ bosh --non-interactive update-cloud-config \ 
 	cloud-config.yml --ops-file UPDATE\_SERVICE\_ACCOUNT 
 
+Your PKS installation is now ready to use. To allow your organization to use the API to create, update, and delete clusters, you will have to share the PKS API endpoint, and provide some IPs for the cluster creation process. Users creating clusters will have to provide an IP for the kubernetes master host. This can be self-service if your organization has a load-balancer-as-a-service tool. There is also a step after cluster creation where the LB has to be linked with the newly created cluster. This is outlined in the 'Using PKS' part of the guide.
+
 ##<a id='retrieve-pks-api'></a> Step 5: Retrieve PKS API Endpoint
 
 Perform the following steps to retrieve the PKS API endpoint:


### PR DESCRIPTION
it's like there's 2 bigger steps: installing the tile (step 1-4), and setting up access to the API/Clusters. (step 5-6)

maybe we need to change structure for this page to call this out - we're not going to solve load balancers for customers for quite a while.