### PR TITLE
Remove step for post deploy config of cloud-config

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -105,52 +105,7 @@ To edit the stemcell configuration, click **Stemcell**. Click **Import Stemcell*
 
 After configuring the tile, return to the Ops Manager Installation Dashboard and click **Apply Changes** to deploy the tile.
 
-##<a id='post-deployment-steps'></a> Step 4: Post-Deployment Steps (GCP Only)
-
-If you are deploying on GCP, you must create a service account and update the [cloud config](http://bosh.io/docs/cloud-config.html) after deploying the tile.
-
-In order for Kubernetes to create load balancers and attach persistent disks to pods, you must create a service account with sufficient permissions. Then you must update the cloud config for all `vm_types` to include a `cloud_properties` value for `service_account`. 
-
-<p class="note"><strong>Note</strong>: You must update the cloud config each time you redeploy PKS by clicking <strong>Apply Changes</strong> in Ops Manager.</p>
-
-Perform the following steps:
-
-1. Navigate to the **IAM & admin > Service accounts** section of the GCP Console.
-1. Click **Create Service Account**.
-1. Enter a name for the service account, and add the following roles:
-  * `roles/iam.serviceAccountActor` (**Project > Service Account Actor**)
-  * `roles/compute.instanceAdmin`  (**Compute Engine > Compute Instance Admin**)
-  * `roles/compute.securityAdmin` (**Compute Engine > Compute Security Admin**)
-  * `roles/compute.networkAdmin` (**Compute Engine > Compute Network Admin**)
-  * `roles/compute.storageAdmin` (**Compute Engine > Compute Storage Admin**)
-  * `roles/compute.viewer` (**Compute Engine > Compute Viewer**)
-	<p class="note"><strong>Note</strong>: See the <code>kubo-deployment</code> GitHub <a href="https://github.com/cloudfoundry-incubator/kubo-deployment/blob/master/docs/user-guide/platforms/gcp/kubo-infrastructure.tf#L61-L110">repository</a> for more information about the required roles.</p>
-1. Click **Furnish a new private key** and select **JSON**.
-1. Click **Create**.
-1. Set the name of the GCP service account as an environment variable. For example:
-	<pre class="terminal">$ GCP\_SERVICE\_ACCOUNT="example-acct<span>@</span>project.iam.gserviceaccount.com"</pre>
-1. Use the BOSH CLI v2 to export your cloud config as a YAML file, specifying the name of your environment:
-	<pre class="terminal">$ bosh -e my-env cloud-config > cloud-config.yml</pre>
-1. Create an environment variable with your VM types. You must have [Ruby](https://www.ruby-lang.org/en/downloads/) and [jq](https://stedolan.github.io/jq/) installed. Enter the following command:
-	<pre class="terminal">$ VM\_TYPES=$(cat cloud-config.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))' | jq -r '.vm\_types[].name')</pre>
-1. Create an empty file with the following command:
-	<pre class="terminal">$ echo "" > UPDATE\_SERVICE\_ACCOUNT</pre>
-1. Enter the following Bash script on the command line:
-
-	```
-	for vm_type in $VM_TYPES
-	do
-	  echo "- type: replace" >> UPDATE_SERVICE_ACCOUNT
-	  echo "  path: /vm_types/name=${vm_type}/cloud_properties/service_account?" >> UPDATE_SERVICE_ACCOUNT
-	  echo "  value: $GCP_SERVICE_ACCOUNT" >> UPDATE_SERVICE_ACCOUNT
-	done
-	```
-1. Use the BOSH CLI v2 to update the cloud config. For example:
-	<pre class="terminal">$ bosh --non-interactive update-cloud-config \ 
-	cloud-config.yml --ops-file UPDATE\_SERVICE\_ACCOUNT</pre>
-   Your PKS installation is now ready to use.
-
-##<a id='retrieve-pks-api'></a> Step 5: Retrieve PKS API Endpoint
+##<a id='retrieve-pks-api'></a> Step 4: Retrieve PKS API Endpoint
 
 You must share the PKS API endpoint to allow your organization to use the API to create, update, and delete clusters.
 


### PR DESCRIPTION
With the upgrade to CFCR 0.10.0 - Available in tile pks-tile/archive/pivotal-container-service-0.5.0-build.125.pivotal - The configuration of the cloud config is not longer necessary