### PR TITLE
Remove reference to serviceAccountActor role

### DIFF
--- a/preparing-gcp.html.md.erb
+++ b/preparing-gcp.html.md.erb
@@ -21,7 +21,6 @@ In order for Kubernetes to create load balancers and attach persistent disks to 
 1. From the GCP Console, select **IAM & admin > Service accounts**.
 1. Click **Create Service Account**.
 1. Enter a name for the service account, and add the following roles:
-  * `roles/iam.serviceAccountActor` (**Project > Service Account Actor**)
   * `roles/compute.instanceAdmin`  (**Compute Engine > Compute Instance Admin**)
   * `roles/compute.securityAdmin` (**Compute Engine > Compute Security Admin**)
   * `roles/compute.networkAdmin` (**Compute Engine > Compute Network Admin**)
@@ -46,9 +45,9 @@ To enable these APIs, perform the following steps:
 1. In the search field, enter `Google Cloud Resource Manager API`. 
 1. On the **Google Cloud Resource Manager API** page, click **Enable**.
 1. To verify that the APIs have been enabled, perform the following steps:
-    1. Log in to GCP using the IAM service account you created in [Set up an IAM Service Account](#iam-account):
+    1. Log in to GCP:
     <pre class="terminal">
-    $ gcloud auth activate-service-account --key-file JSON\_KEY\_FILENAME
+    $ gcloud auth login
     </pre>
     1. List your projects:
     <pre class="terminal">


### PR DESCRIPTION
Because it's only used to login to gcloud to check that the project is setup correctly, but the user can just login instead.
The role has been deleted from GCP settings.

[#154357364]