### PR TITLE
Update docs to use plans, clusters, cluster

### DIFF
--- a/installing-nsx-t.html.md.erb
+++ b/installing-nsx-t.html.md.erb
@@ -271,7 +271,7 @@ In the current version of PKS, NSX-T does not automatically configure a NAT for 
   Developers can use this IP address as the `--external-hostname` value to create a cluster via the PKS CLI. For more information, see [Using PKS](using.html).
 1. Collect the Cluster UUID after cluster has been successfully created. 
    <pre class="terminal">
-   $ pks list-clusters
+   $ pks clusters
    </pre>
 1. Use the `nsx-cli` script to create a NAT rule to allow access to the Kubernetes API for the cluster. Execute the following command:
    <pre class="terminal">

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -305,7 +305,7 @@ Follow the steps below to view the list of deployed Kubernetes cluster with the 
 1. Run the following command to view the list of deployed clusters, including cluster names and status:
   <br>
   ```
-   pks list-clusters
+   pks clusters
   ```
 
 ### View Cluster List with curl Command 
@@ -348,12 +348,12 @@ Follow the steps below to view the details of an individual cluster using the PK
 1. Run the following command to view the details of an individual cluster:
   <br>
   ```
-  pks show-cluster CLUSTER-NAME
+  pks cluster CLUSTER-NAME
   ```
   <br>
   Replace `CLUSTER-NAME` with the unique name for your cluster.
   For example:
-  <pre class="terminal">$ pks show-cluster my-cluster</pre>
+  <pre class="terminal">$ pks cluster my-cluster</pre>
 
 ### View Cluster Details with curl Commands
 
@@ -396,7 +396,7 @@ Follow the steps below to view information about the available plans for deployi
   * `PASSWORD` is your PKS API password.
 
 1. Run the following command to view information about the available plans for deploying a cluster:
-  <pre class="terminal">$ pks list-plans</pre>
+  <pre class="terminal">$ pks plans</pre>
   The response lists details about the available plans, including plan names and descriptions:
   <pre class="terminal">
   Name     ID  Description


### PR DESCRIPTION
Update docs to use plans, clusters, cluster instead of list-plans, list-clusters, show-cluster.

[#154518705]