### PR TITLE
Remove Default Authorization mode from PKS API

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -44,7 +44,6 @@ Perform the following steps:
 Perform the following steps:
 
 1. Click **PKS API**.
-1. Under **Default Authorization Mode**, leave **RBAC** selected. For more information, see the [RBAC Support in Kubernetes](http://blog.kubernetes.io/2017/04/rbac-support-in-kubernetes.html) blog post.
 1. Under **Certificate**, provide your own certificate or have Ops Manager generate one.
 To generate a new certificate and key, enter a wildcard domain you own.
 For example, `*.pks.pcfvsphere.mydomain.com`.
@@ -62,7 +61,7 @@ To activate a plan, perform the following steps:
 1. Under **Plan name**, provide a unique name for the plan.
 1. Under **Plan description**, edit the description as needed.
 The plan description appears in the Services Marketplace, which developers can access by using either the Cloud Foundry Command Line Interface (cf CLI) or Apps Manager.
-1. Under **Default Cluster Authorization Mode**, select an authentication mode for the Kubernetes clusters.
+1. Under **Default Cluster Authorization Mode**, select an authentication mode for the Kubernetes clusters. For more information, see the [RBAC Support in Kubernetes](http://blog.kubernetes.io/2017/04/rbac-support-in-kubernetes.html) blog post.
 1. Under **AZ placement**, select an AZ for the Kubernetes clusters deployed by PKS.
 1. Under **ETCD/Master VM Type**, select the type of VM to use for Kubernetes etcd and master nodes.
 1. Under **Worker VM Type**, select the type of VM to use for Kubernetes worker nodes.


### PR DESCRIPTION
Authoriaztion mode is defined in plans.

+ moved comment to the plans section. (But we are not sure if the comment is required)