### PR TITLE
Update gcp-om-config for creating availability zones

### DIFF
--- a/gcp-om-config.html.md.erb
+++ b/gcp-om-config.html.md.erb
@@ -164,9 +164,9 @@ Manager Resurrector functionality and increase runtime availability.
 1. Select **Create Availability Zones**.
 1. Click **Add**.
 1. For **Google Availability Zone**: 
-    * Enter one of the zones that you associated to the backend service instance groups of the HTTP(S) Load Balancer. For example, if you are using the `us-central1` region and selected `us-central1-a` as one of the zones for your HTTP(S) Load Balancer instance groups, enter `us-central1-a`. 
+    * Enter one of the zones that you associated to the NAT instances. For example, if you are using the `us-central1` region and selected `us-central1-a` as one of the zones for your NAT instances, enter `us-central1-a`. 
     * Click **Add**
-    * Repeat the above step for all the availability zones that you associated to instance groups in [Preparing to Deploy PKS on GCP](./gcp-prepare-env.html#create-http-and-instance-group). 
+    * Repeat the above step for all the availability zones that you associated to instances in [Preparing to Deploy PKS on GCP](./gcp-prepare-env.html#create-nat). 
     <%= image_tag("gcp/availability_zones_multiple.png") %>
     * Click **Save**.
 


### PR DESCRIPTION
As there are no http load balancers (and associated documentation), we are presuming that the availability zones we should be specifying here are the ones associated to the NAT instances.

For instance, if you have 3 subnets (`us-central1`, `us-west1`, `us-east1`) then you have nat instances across each region in a specific az (`us-central1-a`, `us-west1-a`, `us-east1-b`)