### PR TITLE
Update gcp-om-config to include infrastructure network

### DIFF
--- a/gcp-om-config.html.md.erb
+++ b/gcp-om-config.html.md.erb
@@ -215,6 +215,35 @@ Manager Resurrector functionality and increase runtime availability.
       <td><code>192.168.16.1</code></td>
     </tr>
     <tr>
+      <th rowspan="7" width="21%">Infrastructure Network</th>
+      <th>Field</th>
+      <th>Configuration</th>
+    </tr>
+    <tr>
+      <td>Name</td>
+      <td><code>infrastructure</code></td>
+    </tr>
+    <tr>
+      <td>Google Network Name</td>
+      <td><code>MY-PKS-virt-net/MY-PKS-subnet-infrastructure-GCP-REGION/GCP-REGION</code></td>
+    </tr>
+    <tr>
+      <td>CIDR</td>
+      <td><code>192.168.101.0/26</code></td>
+    </tr>
+    <tr>
+      <td>Reserved IP Ranges</td>
+      <td><code>192.168.101.1-192.168.101.9</code></td>
+    </tr>
+    <tr>
+      <td>DNS</td>
+      <td><code>169.254.169.254</code></td>
+    </tr>
+    <tr>
+      <td>Gateway</td>
+      <td><code>192.168.101.1</code></td>
+    </tr>
+      <tr>
       <th rowspan="7" width="21%">Service Network</th>
       <th>Field</th>
       <th>Configuration</th>


### PR DESCRIPTION
The infrastructure network was created in prepare-env and needs to be added to the om configuration so that it can be used  in the subsequent step (`Assign AZs and Networks Page`)

cc @desmondrawls 