### PR TITLE
rename infrastructure network

### DIFF
--- a/gcp-om-config.html.md.erb
+++ b/gcp-om-config.html.md.erb
@@ -218,7 +218,7 @@ Manager Resurrector functionality and increase runtime availability.
     </tr>
     <tr>
       <td>Name</td>
-      <td><code>infrastructure</code></td>
+      <td><code>pks-infrastructure</code></td>
     </tr>
     <tr>
       <td>Google Network Name</td>
@@ -275,7 +275,7 @@ Manager Resurrector functionality and increase runtime availability.
 
 1. Select **Assign AZs and Networks**.
 1. Use the drop-down menu to select a **Singleton Availability Zone**. The Ops Manager Director installs in this Availability Zone.
-1. Under **Network**, select the `infrastructure` network for your Ops Manager Director.
+1. Under **Network**, select the `pks-infrastructure` network for your Ops Manager Director.
 1. Click **Save**.
 
 ## <a id='security'></a>Step 7: Security Page ##


### PR DESCRIPTION
the networks are named `pks-main`, `pks-services`, and `infrastructure`.   Suggestion that
we rename `infrastructure` to `pks-infrastructure` for consistency.