### PR TITLE
Add LDAP documentation

### DIFF
--- a/installing-pks-gcp.html.md.erb
+++ b/installing-pks-gcp.html.md.erb
@@ -111,8 +111,80 @@ Perform the following steps:
 
 1. Click **UAA**.
 1. For **UAA URL**, enter the hostname you use for accessing the PKS API service.
-1. Enter the time (in seconds) for the PKS CLI access token lifetime.
-1. Enter the time (in seconds) for the PKS CLI refresh token lifetime.
+1. Enter the time (in seconds) for the **PKS CLI Access Token Lifetime**.
+1. Enter the time (in seconds) for the **PKS CLI Refresh Token Lifetime**.
+
+####<a id='configure-ldap'></a> Configure LDAP as an Identity Provider for PKS
+
+To integrate the UAA with one or more LDAP servers, configure PKS with your LDAP endpoint information as follows:
+
+1. Under **UAA**, select **LDAP Server**.
+
+1. For **Server URL**, enter the URL(s) that point your LDAP server(s). With 
+multiple LDAP servers, separate their URLs with spaces. Each URL must include 
+one of the following protocols:
+    * `ldap://`: This specifies that the LDAP server uses an unencrypted 
+connection.
+    * `ldaps://`: This specifies that the LDAP server uses SSL for an encrypted connection and requires that the LDAP server holds a trusted certificate or that you import a trusted certificate to the JVM truststore.
+
+1. For **LDAP Credentials**, enter the LDAP Distinguished Name (DN) and 
+password for binding to the LDAP Server. Example DN: `cn=administrator,ou=Users,dc=example,dc=com`
+    <p class="note"><strong>Note</strong>: Pivotal recommends that you provide LDAP credentials that grant read-only permissions on the LDAP Search Base and the LDAP Group Search Base. In addition to this, if the bind user belongs to a different search base, you must use the full DN.</p>
+
+1. For **User Search Base**, enter the location in the LDAP directory tree from 
+which any LDAP User search begins. The typical LDAP Search Base matches your 
+domain name.
+<br><br>
+For example, a domain named "cloud.example.com" typically uses the following LDAP User Search Base: `ou=Users,dc=example,dc=com`
+
+1. For **User Search Filter**, enter a string that defines LDAP User search 
+criteria. These search criteria allow LDAP to perform more effective and 
+efficient searches. For example, the standard LDAP search filter `cn=Smith` 
+returns all objects with a common name equal to `Smith`.
+<br><br>
+In the LDAP search filter string that you use to configure PKS, use `{0}` 
+instead of the username. For example, use `cn={0}` to return 
+all LDAP objects with the same common name as the username.
+<br><br>
+In addition to `cn`, other attributes commonly searched for and returned are 
+`mail`, `uid` and, in the case of Active Directory, `sAMAccountName`.
+    <p class="note"><strong>Note</strong>: For instructions for testing and troubleshooting your LDAP search filters, see the [Configuring LDAP Integration with Pivotal Cloud Foundry](https://discuss.zendesk.com/hc/en-us/articles/204140418-Configuring-LDAP-Integration-with-Pivotal-Cloud-Foundry-) Knowledge Base article.</p>
+
+1. For **Group Search Base**, enter the location in the LDAP directory tree 
+from which the LDAP Group search begins.
+<br><br>
+For example, a domain named "cloud.example.com" typically uses the following 
+LDAP Group Search Base: `ou=Groups,dc=example,dc=com`
+<br><br>
+Follow the instructions in the [Grant Admin Permissions to an External Group 
+(SAML or LDAP)](../manage-users.html#external-group) section 
+of _Creating and Managing Users with the UAA CLI (UAAC)_ to map the 
+groups under this search base to admin roles in PKS.
+
+1. For **Group Search Filter**, enter a string that defines LDAP Group search 
+criteria. The standard value is `member={0}`.
+
+1. For **Server SSL Cert**, paste in the root certificate from your CA 
+certificate or your self-signed certificate.
+
+1. If you are using `ldaps://` with a self-signed certificate, enter a Subject 
+Alternative Name for your certificate under **Server SSL Cert AltName**. 
+Otherwise, leave this field blank.
+
+1. For **First Name Attribute** and **Last Name Attribute**, enter the 
+attribute names in your LDAP directory that correspond to the first and last 
+names in each user record, for example `cn` and `sn`.
+
+1. For **Email Attribute**, enter the attribute name in your LDAP directory 
+that corresponds to the email address in each user record, for example `mail`.
+
+1. For **Email Domain(s)**, enter a comma-separated list of the email domains 
+for external users who will receive invitations to Apps Manager.
+
+1. For **LDAP Referrals**, choose how the UAA handles LDAP server referrals out 
+to other external user stores. The UAA can follow the external referrals, 
+ignore them without returning errors, or throw an error for each external 
+referral and abort the authentication.
 
 ###<a id='syslog'></a> (Optional) Syslog
 

--- a/installing-pks-vsphere.html.md.erb
+++ b/installing-pks-vsphere.html.md.erb
@@ -118,8 +118,80 @@ Perform the following steps:
 
 1. Click **UAA**.
 1. For **UAA URL**, enter the hostname you use for accessing the PKS API service.
-1. Enter the time (in seconds) for the PKS CLI access token lifetime.
-1. Enter the time (in seconds) for the PKS CLI refresh token lifetime.
+1. Enter the time (in seconds) for the **PKS CLI Access Token Lifetime**.
+1. Enter the time (in seconds) for the **PKS CLI Refresh Token Lifetime**.
+
+####<a id='configure-ldap'></a> Configure LDAP as an Identity Provider for PKS
+
+To integrate the UAA with one or more LDAP servers, configure PKS with your LDAP endpoint information as follows:
+
+1. Under **UAA**, select **LDAP Server**.
+
+1. For **Server URL**, enter the URL(s) that point your LDAP server(s). With 
+multiple LDAP servers, separate their URLs with spaces. Each URL must include 
+one of the following protocols:
+    * `ldap://`: This specifies that the LDAP server uses an unencrypted 
+connection.
+    * `ldaps://`: This specifies that the LDAP server uses SSL for an encrypted connection and requires that the LDAP server holds a trusted certificate or that you import a trusted certificate to the JVM truststore.
+
+1. For **LDAP Credentials**, enter the LDAP Distinguished Name (DN) and 
+password for binding to the LDAP Server. Example DN: `cn=administrator,ou=Users,dc=example,dc=com`
+    <p class="note"><strong>Note</strong>: Pivotal recommends that you provide LDAP credentials that grant read-only permissions on the LDAP Search Base and the LDAP Group Search Base. In addition to this, if the bind user belongs to a different search base, you must use the full DN.</p>
+
+1. For **User Search Base**, enter the location in the LDAP directory tree from 
+which any LDAP User search begins. The typical LDAP Search Base matches your 
+domain name.
+<br><br>
+For example, a domain named "cloud.example.com" typically uses the following LDAP User Search Base: `ou=Users,dc=example,dc=com`
+
+1. For **User Search Filter**, enter a string that defines LDAP User search 
+criteria. These search criteria allow LDAP to perform more effective and 
+efficient searches. For example, the standard LDAP search filter `cn=Smith` 
+returns all objects with a common name equal to `Smith`.
+<br><br>
+In the LDAP search filter string that you use to configure PKS, use `{0}` 
+instead of the username. For example, use `cn={0}` to return 
+all LDAP objects with the same common name as the username.
+<br><br>
+In addition to `cn`, other attributes commonly searched for and returned are 
+`mail`, `uid` and, in the case of Active Directory, `sAMAccountName`.
+    <p class="note"><strong>Note</strong>: For instructions for testing and troubleshooting your LDAP search filters, see the [Configuring LDAP Integration with Pivotal Cloud Foundry](https://discuss.zendesk.com/hc/en-us/articles/204140418-Configuring-LDAP-Integration-with-Pivotal-Cloud-Foundry-) Knowledge Base article.</p>
+
+1. For **Group Search Base**, enter the location in the LDAP directory tree 
+from which the LDAP Group search begins.
+<br><br>
+For example, a domain named "cloud.example.com" typically uses the following 
+LDAP Group Search Base: `ou=Groups,dc=example,dc=com`
+<br><br>
+Follow the instructions in the [Grant Admin Permissions to an External Group 
+(SAML or LDAP)](../manage-users.html#external-group) section 
+of _Creating and Managing Users with the UAA CLI (UAAC)_ to map the 
+groups under this search base to admin roles in PKS.
+
+1. For **Group Search Filter**, enter a string that defines LDAP Group search 
+criteria. The standard value is `member={0}`.
+
+1. For **Server SSL Cert**, paste in the root certificate from your CA 
+certificate or your self-signed certificate.
+
+1. If you are using `ldaps://` with a self-signed certificate, enter a Subject 
+Alternative Name for your certificate under **Server SSL Cert AltName**. 
+Otherwise, leave this field blank.
+
+1. For **First Name Attribute** and **Last Name Attribute**, enter the 
+attribute names in your LDAP directory that correspond to the first and last 
+names in each user record, for example `cn` and `sn`.
+
+1. For **Email Attribute**, enter the attribute name in your LDAP directory 
+that corresponds to the email address in each user record, for example `mail`.
+
+1. For **Email Domain(s)**, enter a comma-separated list of the email domains 
+for external users who will receive invitations to Apps Manager.
+
+1. For **LDAP Referrals**, choose how the UAA handles LDAP server referrals out 
+to other external user stores. The UAA can follow the external referrals, 
+ignore them without returning errors, or throw an error for each external 
+referral and abort the authentication.
 
 
 ###<a id='syslog'></a> (Optional) Syslog

--- a/manage-users.html.md.erb
+++ b/manage-users.html.md.erb
@@ -35,3 +35,23 @@ Run `uaac member add UAA-SCOPE USERNAME`, replacing `UAA-SCOPE` with one of the 
 
     For example:
     <pre class="terminal">$ uaac member add pks.clusters.admin alana</pre>
+
+##<a id='external-group'></a> Grant Permission to an External Group
+
+Follow the steps below to grant all users under an external group admin permissions.
+
+1. Obtain the credentials of an admin client created using UAAC [as above](#uaa-admin).
+
+1. Run `uaac token client get admin -s ADMIN-CLIENT-SECRET` to authenticate and obtain an access token for the admin client from the UAA server. Replace 
+`ADMIN-CLIENT-SECRET` with your admin secret.
+UAAC stores the token in `~/.uaac.yml`.
+    <pre class="terminal">
+    $ uaac token client get admin -s MyAdminSecret
+    </pre>
+
+1. Run the commands below to grant all users under the mapped LDAP Group admin permissions. Replace `GROUP-DISTINGUISHED-NAME` with an appropriate group name. 
+    * `uaac group map --name pks.clusters.admin "GROUP-DISTINGUISHED-NAME"`
+
+1. Run the commands below to grant all users under the mapped LDAP Group users permissions. Replace `GROUP-DISTINGUISHED-NAME` with an appropriate group name. 
+    * `uaac group map --name pks.clusters.manage "GROUP-DISTINGUISHED-NAME"`
+


### PR DESCRIPTION
We copy-pasted documentation for PAS

Also, we put it in both vSphere and GCP. Is there a better way to manage documentation without duplication? vSphere and GCP parts are pretty the same expect 1 section

[#154629571]

Signed-off-by: Oleksandr Slynko <oslynko@pivotal.io>