### PR TITLE
NSX scripts require jq tool

### DIFF
--- a/installing-nsx-t.html.md.erb
+++ b/installing-nsx-t.html.md.erb
@@ -282,6 +282,7 @@ In the current version of PKS, NSX-T does not automatically configure a NAT for 
   <pre class="terminal">
   $ sudo apt-get install git
   $ sudo apt-get install -y httpie 
+  $ sudo apt-get install jq
   </pre>
 1. One of the files from the tarball is `nsx-cli.sh`. Make the script executable:
   <pre class="terminal">


### PR DESCRIPTION
The NSX scripts now requires `jq` installed, otherwise, user will get this error message:

```
$ ./nsx-cli.sh
[error] requires jq installed
```