### PR TITLE
Some fixes for Helm docs

### DIFF
--- a/configure-tiller-helm.html.md.erb
+++ b/configure-tiller-helm.html.md.erb
@@ -7,12 +7,7 @@ Tiller runs inside the Kubernetes cluster and requires access to the Kubernetes 
 If you use role-based access control (RBAC) in PKS, perform the steps in this section to grant
 Tiller permission to access the API.
 
-1. Create a service account for Tiller by running the following command:
-  <pre class="terminal">
-  $ kubectl create serviceaccount tiller --namespace kube-system
-  </pre>
-
-1. Bind the service account to the `cluster-admin` role by adding the following section to `rbac-config.yaml`:
+1. Create a service account for Tiller and bind it to the `cluster-admin` role by adding the following section to `rbac-config.yaml`:
 
     ```yaml
     apiVersion: v1
@@ -35,10 +30,12 @@ Tiller permission to access the API.
         namespace: kube-system
     ```
 
-1. Apply the role by running the following command:
+1. Apply the service account and role by running the following command:
   <pre class="terminal">
   $ kubectl create -f rbac-config.yaml
   </pre>
+
+1. Download and install [Helm CLI](https://github.com/kubernetes/helm/releases) for your operating system.
 
 1. Deploy Helm using the service account by running the following command:
   <pre class="terminal">


### PR DESCRIPTION
* Add link to install Helm cli
* Remove unnecessary manual service account creation, as it will be created at the `rbac-config.yaml` apply, otherwise, the user will get this error:

```
$ kubectl create serviceaccount tiller --namespace kube-system
serviceaccount "tiller" created
$ kubectl create -f rbac-config.yaml
clusterrolebinding "tiller" created
Error from server (AlreadyExists): error when creating "rbac-config.yaml": serviceaccounts "tiller" already exists
```