### PR TITLE
pks login cannot use an IP address

### DIFF
--- a/create-cluster.html.md.erb
+++ b/create-cluster.html.md.erb
@@ -19,7 +19,7 @@ Use one of the following methods, depending on your PKS installation:
   pks login -a PKS_API -u USERNAME -p PASSWORD
   </pre>
   Replace the placeholder values in the command as follows:
-  * `PKS_API` is your PKS API hostname. For example, `10.85.102.12`. The PKS CLI uses port 9021 by default.
+  * `PKS_API` is your PKS API hostname. For example, `pks.example.com`. The PKS CLI uses port 9021 by default.
   * `USERNAME` is your PKS API username.
   * `PASSWORD` is your PKS API password.
 


### PR DESCRIPTION
With the introduction of UAA the hostname used for login must match the value configured for UAA url which should be the same as the DNS entry created to point at the PKS API.