### PR TITLE
Save cluster credentials to a custom KUBECONFIG.

### DIFF
--- a/cluster-credentials.html.md.erb
+++ b/cluster-credentials.html.md.erb
@@ -25,5 +25,7 @@ You can use the `pks get-credentials` command to perform the following actions:
 The `kubeconfig` file path works the same way as `kubectl`.
 If you do not set the file path, the default path is `$HOME/.kube/config`.
 Use the `KUBECONFIG` environment variable to change the `kubeconfig` file path.
+For example:
+<pre class="terminal">$ KUBECONFIG=/path/to/my-cluster.config pks get-credentials my-cluster</pre>
 
 You can use the credentials and the `kubeconfig` to deploy application workloads to your cluster with `kubectl`. For more information about accessing your cluster, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/).


### PR DESCRIPTION
Add example of how to save the pks cluster credentials to a custom KUBECONFIG file.