### PR TITLE
User should not login with port 8443 in url

### DIFF
--- a/configure-api.html.md.erb
+++ b/configure-api.html.md.erb
@@ -45,5 +45,5 @@ See the [Grant Cluster Access](manage-users.html#uaa-scopes) section of _Managin
 Replace the `UAA-URL` with the URL of your UAA server, `USERNAME` with your username, and `PASSWORD` with your password.
 For example:
   <pre class="terminal">
-  $ pks login -a https&#58;//pks.example.com:8443 -u alana -p my-password -k
+  $ pks login -a https&#58;//pks.example.com -u alana -p my-password -k
   </pre>


### PR DESCRIPTION
If a user attaches the 8443 port to the url, login will be successful but any other command afterwards will fail.

If they have 9021, it will work, but it is not necessary either.