### PR TITLE
Improve wording for restarted VMs during upgrade

### DIFF
--- a/release-notes/1.0.2.html.md.erb
+++ b/release-notes/1.0.2.html.md.erb
@@ -182,7 +182,7 @@ During an upgrade to v1.0.2 on vSphere, persistent storage volumes do not reatta
 
 This issue occurs when you deploy a pod with persistent storage attached, drain the node, and then immediately delete the node VM.
 
-The expected behavior is for persistent disks to reattach to rolled VMs after the pod is restored.
+The expected behavior is for persistent disks to reattach to the upgraded VMs after the pod is restored.
 However, a Kubernetes bug prevents the disk from reattaching.
 PKS v1.0.2 works around this bug by attaching the volumes after all workers are upgraded.
 


### PR DESCRIPTION
The wording of the phrase "rolled" VMs might be unclear to customers. Proposing this fix to improve this wording.