### PR TITLE
Fix kubectl statefulset pods command

### DIFF
--- a/release-notes/1.0.2.html.md.erb
+++ b/release-notes/1.0.2.html.md.erb
@@ -166,7 +166,7 @@ After upgrading PKS to v1.0.2, manually deleting and recreating all preexisting 
 
 To get all StatefulSets pods, run the following command on every Kubernetes cluster using the Kubernetes admin user permissions:
 
-<pre>$ kubectl get pods -l "statefulset.kubernetes.io/POD-NAME" \
+<pre>$ kubectl get pods -l "statefulset.kubernetes.io/pod-name" \
 -o wide --all-namespaces</pre>
 
 For each result, delete the pod by running the following command:


### PR DESCRIPTION
The `kubectl` commands need to use the specific label selector `statefulset.kubernetes.io/pod-name`. If we use `POD-NAME` (capital), it may be confused by customers as they need to provide the name of the pod, and this is not the case.