### PR TITLE
Update diagnostic-tools.html.md.erb

### DIFF
--- a/diagnostic-tools.html.md.erb
+++ b/diagnostic-tools.html.md.erb
@@ -40,5 +40,5 @@ For more information, see [Advanced Troubleshooting with the BOSH CLI](https://d
   </pre>
 
 1. Examine the following file:
-  * On the PKS master VM, examine the `kubernetes-api` log file.
+  * On the PKS master VM, examine the `kube-apiserver` log file.
   * On a PKS worker VM, examine the `kubelet` log file.


### PR DESCRIPTION
There is no kubenetes-api folder in PKS 1.0.2. It should read kube-apiserver