### PR TITLE
Add back important "public subnet" context

### DIFF
--- a/deploy-workloads.html.md.erb
+++ b/deploy-workloads.html.md.erb
@@ -28,7 +28,7 @@ If you use AWS, perform the following steps before you create a load balancer:
 
 1. Record the unique identifier for the cluster.
 
-1. In the [AWS Management Console](https://aws.amazon.com/console/), enter the tag shown in the table below, replacing `CLUSTER-UUID` with the unique identifier of the cluster. Leave the **Value** field blank.
+1. In the [AWS Management Console](https://aws.amazon.com/console/), tag each public subnet based on the table below, replacing `CLUSTER-UUID` with the unique identifier of the cluster. Leave the **Value** field blank.
   <table>
     <tr>
       <th>Key</th>


### PR DESCRIPTION
Seems like the public subnet keywords got dropped. Adding them back in