### PR TITLE
Update docs to note ABAC removal in 1.1

### DIFF
--- a/installing-pks.html.md.erb
+++ b/installing-pks.html.md.erb
@@ -88,7 +88,6 @@ To activate a plan, perform the following steps:
 1. Under **Description**, edit the description as needed.
 The plan description appears in the Services Marketplace, which developers can access by using PKS CLI.
 1. Under **AZ Placement**, select one or more AZs for the Kubernetes clusters deployed by PKS. If you select more than one AZ, PKS deploys the master VM in the first AZ and the worker VMs across the remaining AZs.
-1. Under **Default Cluster Authorization Mode**, select an authentication mode for the Kubernetes clusters. Pivotal recommends selecting **RBAC**. For more information, see [Authorization Overview](https://kubernetes.io/docs/reference/access-authn-authz/authorization) in the Kubernetes documentation.
 1. Under **Master/ETCD Node Instances**, select the default number of Kubernetes master/etcd nodes to provision for each cluster. You can enter either 1 or 3. Set this value to 3 for increased master node availability.
   <p class="note warning"><strong>WARNING</strong>: To change the number of master/etcd nodes, you must ensure that no existing clusters are using this plan. PKS does not support changing the number of master/etcd nodes for plans with existing clusters.</p>
 1. Under **ETCD/Master VM Type**, select the type of VM to use for Kubernetes master/etcd nodes.

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -23,6 +23,7 @@ owner: PKS
 * Adds support for NO-NAT deployment topologies for PKS installations on NSX-T. See [Installing and Configuring PKS with NSX-T Integration](installing-nsx-t.html) for more information.
 * Adds support for integration with [(VMware Analytics Cloud (VAC)](https://codepen.io/didkobravo/project/live/AYdRpX) to capture telemetry information.
 * Adds support for deploying multiple masters (with multi-etcd instances) across Availability Zones (AZs).
+* Improves security by removing ABAC authorization option for clusters.
 
 ### <a id="v1.1.0-fixed"></a>Fixed Issues
 
@@ -108,3 +109,6 @@ PKS v1.1.0 includes or supports the following component versions:
 
 This section includes known issues with PKS v1.1.0 and corresponding workarounds.
 
+#### <a id="upgrading-abac"></a>Upgrading ABAC Clusters
+
+ABAC is no longer supported in 1.1. All existing ABAC clusters will be migrated to RBAC. When upgrading these clusters, there will be a small period of downtime for kube-system pods. Additionally, any workloads using service accounts in ABAC will stop working after the upgrade. To fix these workloads, they will need to use RBAC.


### PR DESCRIPTION
We also were not sure if we should note somewhere in the docs now that RBAC is default for all clusters, as we removed the selector in the tile.

[#157803176]

Signed-off-by: Angela Chin <achin@pivotal.io>