### PR TITLE
Changed location of UAA admin creds for PKS 1.1.0

### DIFF
--- a/configure-api.html.md.erb
+++ b/configure-api.html.md.erb
@@ -36,7 +36,7 @@ For example:
 
 1. Run `uaac token client get admin -s UAA-ADMIN-SECRET` to request a token from the UAA server.
 Replace `UAA-ADMIN-SECRET` with your UAA admin secret.
-Refer to **Ops Manager > Pivotal Container Service > Credentials > Uaa Admin Secret** to retrieve this value.
+Refer to **Ops Manager > Pivotal Container Service > Credentials > Pks Uaa Management Admin Client** to retrieve this value.
 
 1. Grant cluster access to new or existing users with UAA.
 For more information on granting cluster access to users or creating users, see the [Grant Cluster Access to a User](manage-users.html#uaa-scopes) section of _Managing Users in UAA_.


### PR DESCRIPTION
The property name for the PKS UAA admin client credentials in PKS 1.1.0 changed from "Uaa Admin Secret" to "Pks Uaa Management Admin Client".