### PR TITLE
Cloud provider for GCP updated to ask for service account name

### DIFF
--- a/gcp-prepare-env.html.md.erb
+++ b/gcp-prepare-env.html.md.erb
@@ -59,7 +59,7 @@ You need separate service accounts for Kubernetes cluster master and worker node
 1. Select **Furnish a new private key** and select **JSON**.
 1. Click **Create**.
 Your browser automatically downloads a JSON file with a private key for this account.
-Save this file in a secure location.
+This file will not be needed by PKS. PKS only requires the Service Account Name.
 
 ### <a id='create-worker'></a>Create the Worker Node Service Account
 
@@ -69,7 +69,7 @@ Save this file in a secure location.
 1. Select **Furnish a new private key** and select **JSON**.
 1. Click **Create**.
 Your browser automatically downloads a JSON file with a private key for this account.
-Save this file in a secure location.
+This file will not be needed by PKS. PKS only requires the Service Account Name.
 
 ### <a id='create-bosh-ops-man'></a> Create the BOSH / Ops Manager Service Account
 

--- a/installing-pks.html.md.erb
+++ b/installing-pks.html.md.erb
@@ -129,8 +129,8 @@ Ensure the values in the following procedure match those in the **Google Config*
 
 1. Enter your **GCP Project Id**, which is the name of the deployment in your Ops Manager environment.
 1. Enter your **VPC Network**, which is the VPC network name for your Ops Manager environment.
-1. Enter your **GCP Master Service Account Key**. For information about configuring this key, see [Create the Master Node Service Account](gcp-prepare-env.html#create-master).
-1. Enter your **GCP Worker Service Account Key**. For information about configuring this key, see [Create the Worker Node Service Account](gcp-prepare-env.html#create-worker).
+1. Enter your **GCP Master Service Account Name**. This is the email associated with the Master Service Account Key. For information about configuring this key, see [Create the Master Node Service Account](gcp-prepare-env.html#create-master).
+1. Enter your **GCP Worker Service Account Name**. This is the email associated with the Worker Service Account Key. For information about configuring this key, see [Create the Worker Node Service Account](gcp-prepare-env.html#create-worker).
 1. Click **Save**.
 
 ###<a id='syslog'></a> (Optional) Logging


### PR DESCRIPTION
+ The service account key is no longer required, only the email
associated with the service account.

[#156880686]

Signed-off-by: Neil Hickey <nhickey@pivotal.io>