### PR TITLE
Update the PKS API Load Balancer documentation to be more clear

### DIFF
--- a/gcp-api-load-balancer.html.md.erb
+++ b/gcp-api-load-balancer.html.md.erb
@@ -33,7 +33,7 @@ To create a load balancer using GCP, perform the following steps:
 
 1. Select **Backend configuration**.
    * Under **Region**, select the region where you deployed Ops Manager.
-   * Under **Backends**, leave **Select existing instances** selected. You point the PKS API instance to the backend later in this procedure.
+   * Under **Backends**, leave **Select existing instances** selected. This will be automatically configured when updating the [Resource Config](installing-pks.html#resource-config) section of the PKS tile.
    * (Optional) Select a backup pool.
    * (Optional) Select whether you want to create a health check or go without one.
    * Select a session affinity configuration.

--- a/installing-pks.html.md.erb
+++ b/installing-pks.html.md.erb
@@ -300,7 +300,7 @@ To modify the resource usage of PKS, click **Resource Config** and edit the **Pi
 <p class="note"><strong>Note</strong>: If you experience timeouts or slowness when interacting with the PKS API, select a <strong>VM Type</strong> with greater CPU and memory resources for the <strong>Pivotal Container Service</strong> job.</p>
 
 If you are using GCP, enter a name for your PKS API load balancer that begins with `tcp:` in the **Load Balancers** column.
-For example, `tcp:pks-api`.
+For example, `tcp:pks-api`, where `pks-api` is the name that you configured in Step 6 of [Configuring a GCP Load Balancer](gcp-api-load-balancer.html#create-lb).
 For more information, see [Configuring a GCP Load Balancer for the PKS API](gcp-api-load-balancer.html).
 
 ##<a id='apply-changes'></a> Step 3: Apply Changes


### PR DESCRIPTION
+ when configuring a LB, it now points to the resource config section
where an operator would input the LB name in the tile

[#158179643]