### PR TITLE
Remove outdated information about downloading json for gcp accounts

### DIFF
--- a/gcp-prepare-env.html.md.erb
+++ b/gcp-prepare-env.html.md.erb
@@ -56,20 +56,12 @@ You need separate service accounts for Kubernetes cluster master and worker node
       * **Compute Viewer**
   * **IAM**
       * **Service Account User**
-1. Select **Furnish a new private key** and select **JSON**.
-1. Click **Create**.
-Your browser automatically downloads a JSON file with a private key for this account. Save this file in a secure location.
-  <p class="note"><strong>Note</strong>: The private key file is not used by PKS. When you configure the PKS tile, you provide the <strong>Service account ID</strong> only.</p>
 
 ### <a id='create-worker'></a>Create the Worker Node Service Account
 
 1. From the GCP Console, select **IAM & admin > Service accounts**.
 1. Click **Create Service Account**.
 1. Enter a name for the service account, and add the **Compute Engine > Compute Viewer** role.
-1. Select **Furnish a new private key** and select **JSON**.
-1. Click **Create**.
-Your browser automatically downloads a JSON file with a private key for this account. Save this file in a secure location.
-  <p class="note"><strong>Note</strong>: The private key file is not used by PKS. When you configure the PKS tile, you provide the <strong>Service account ID</strong> only.</p>
 
 ### <a id='create-bosh-ops-man'></a> Create the BOSH / Ops Manager Service Account
 


### PR DESCRIPTION
In pks 1.1.x is not going to be more necessary to add the JSON key when setting up the cloud provider. Only the service account id is going to be necessary. 

This part of the documentation can be removed because not more necessary. 

[#158457770]