### PR TITLE
clarifies the location of UAA for pks-cli

### DIFF
--- a/manage-users.html.md.erb
+++ b/manage-users.html.md.erb
@@ -68,7 +68,7 @@ To retrieve the PKS UAA management admin client secret, do the following:
 1. To view the secret, click **Link to Credential** next to **Pks Uaa Management Admin Client**. The client username is `admin`.
 1. On the command line, run the following command to target your UAA server:
   <pre>`uaac target https://PKS-API:8443 --ca-cert ROOT-CA-FILENAME`</pre>
-  Replace `PKS-API` with the URL of your UAA server. You configured this URL in the PKS API section of [Installing and Configuring PKS](installing-pks.html#pks-api). Replace `ROOT-CA-FILENAME` with the certificate file you downloaded in [Configure Access to the PKS API](configure-api.html#access).
+  Replace `PKS-API` with the URL to your PKS API server. You configured this URL in the PKS API section of [Installing and Configuring PKS](installing-pks.html#pks-api). Replace `ROOT-CA-FILENAME` with the certificate file you downloaded in [Configure Access to the PKS API](configure-api.html#access).
   For example:
     <pre class="terminal">
     $ uaac target api.pks.example.com:8443 --ca-cert my-cert.cert


### PR DESCRIPTION
* there are two uaa servers in the deployment, one on the opsman and the uaa server on the pks api instance
* the user should target the uaa running on the pks api instance