### PR TITLE
Adding to RNs compatible versions for NSX-T and NCP

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -36,6 +36,14 @@ This topic contains release notes for Pivotal Container Service (PKS) v1.1.x.
         <td>Kubernetes version</td>
         <td>v1.10.5
     </tr>
+        <tr>
+        <td>NSX-T version</td>
+        <td>v2.1
+    </tr>
+    <tr>
+        <td>NCP version</td>
+        <td>v2.2
+    </tr>
 </table>
 
 ### <a id="v1.1.4-what's-new"></a>What's New

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -36,13 +36,13 @@ This topic contains release notes for Pivotal Container Service (PKS) v1.1.x.
         <td>Kubernetes version</td>
         <td>v1.10.5
     </tr>
-        <tr>
+    <tr>
         <td>NSX-T version</td>
-        <td>v2.1
+        <td>v2.1</td>
     </tr>
     <tr>
         <td>NCP version</td>
-        <td>v2.2
+        <td>v2.2</td>
     </tr>
 </table>
 


### PR DESCRIPTION
@mjgutermuth Adds the compatible software versions for NSX-T and NCP to the Product Snapshot section of the PKS 1.1 release notes. Based on feedback from VMW field eng. thanks