### PR TITLE
Link directly to Wavefront PKS Documentation

### DIFF
--- a/installing-pks.html.md.erb
+++ b/installing-pks.html.md.erb
@@ -293,7 +293,7 @@ UAA can follow the external referrals, ignore them without returning errors, or 
 ###<a id='monitoring'></a> (Optional) Monitoring
 
 You can monitor Kubernetes clusters and pods metrics externally using the integration with [Wavefront by VMware](https://www.wavefront.com/).
-<p class="note"><strong>Note</strong>: Before you configure the Wavefront integration, you must have an active Wavefront account and access to a Wavefront instance. You provide your Wavefront access token during configuration. For instructions and additional information, see the [Wavefront documentation](https://docs.wavefront.com/).</p>
+<p class="note"><strong>Note</strong>: Before you configure the Wavefront integration, you must have an active Wavefront account and access to a Wavefront instance. You provide your Wavefront access token during configuration. For instructions and additional information, see the [Wavefront documentation](https://docs.wavefront.com/pks.html).</p>
 
 By default, monitoring is disabled. To enable and configure Wavefront monitoring, do the following:
 


### PR DESCRIPTION
Instead of linking the generic Wavefront doc site, we should link directly to their PKS page.