### PR TITLE
PKS 1.1 does not support vSphere 6.5 U2, removing

### DIFF
--- a/vsphere-requirements.html.md.erb
+++ b/vsphere-requirements.html.md.erb
@@ -24,7 +24,7 @@ PKS on vSphere supports the following vSphere component versions:
     <th>Editions</th>
   </tr>
   <tr>
-    <td><ul><li>VMware vSphere 6.5 U2</li><li>VMware vSphere 6.5 U1</li><li>VMware vSphere 6.5 GA</li></ul></td>
+    <td><ul><li>VMware vSphere 6.5 U1</li><li>VMware vSphere 6.5 GA</li></ul></td>
     <td><ul><li>vSphere Enterprise Plus</li><li>vSphere with Operations Management Enterprise Plus</li></ul></td>
   </tr>
 </table>


### PR DESCRIPTION
@mjgutermuth @vikafed Per Anish we need to remove vSphere 6.5 U2 from the support matrix. Thanks.