### PR TITLE
Nsxt res ips

### DIFF
--- a/nsxt-prepare-env.html.md.erb
+++ b/nsxt-prepare-env.html.md.erb
@@ -48,19 +48,21 @@ For more information, see [Networking](installing-nsx-t.html#networking) in _Ins
 
 ####<a id='reserved-ip-blocks'></a>Reserved IP Blocks
 
-Do not use any of the IP blocks listed in this section for pods or nodes.
-If you create Kubernetes clusters with any of the blocks listed below, the Kubernetes worker nodes cannot reach Harbor or internal Kubernetes services.
+Do not use any of the IP blocks listed in this section for pods or nodes. If you create Kubernetes clusters with any of the blocks listed below, the Kubernetes worker nodes cannot reach Harbor or internal Kubernetes services.
 
-Harbor uses the following IP blocks for its internal bridges:
+IP addresses in the following CIDR range must not be used because the Docker daemon on the Kubernetes worker node is using the subnet:
 
-  * 172.17.0.1/16
-  * 172.18.0.1/16
-  * 172.19.0.1/16
-  * 172.20.0.1/16
-  * 172.21.0.1/16
-  * 172.22.0.1/16
+  * 172.17.0.0/16
 
-Each cluster uses the following IP block for Kubernetes services:
+If PKS is deployed with Harbor, IP addresses in the following CIDR ranges must not be used because Harbor is using them for its internal Docker bridges:
+
+  * 172.18.0.0/16
+  * 172.19.0.0/16
+  * 172.20.0.0/16
+  * 172.21.0.0/16
+  * 172.22.0.0/16
+
+The following IP block must not be used for the Nodes IP Block because each Kubernetes cluster uses this subnet for Kubernetes services:
 
   * 10.100.200.0/24
 

--- a/nsxt-topologies.html.md.erb
+++ b/nsxt-topologies.html.md.erb
@@ -48,3 +48,5 @@ This topology has the following characteristics:
 * PKS control plane (Ops Manager, BOSH Director, and PKS VM) components are using corporate routable IP addresses.
 * Kubernetes cluster master and worker nodes are using corporate routable IP addresses.
 * The PKS control plane is deployed inside of the NSX-T network. Both the PKS control plane components (VMs) and the Kubernetes Nodes use corporate routable IP addresses.
+
+<p class="note"><strong>Note</strong>: PKS does not support the use of NSX-T edge clusters on bare metal.</p>


### PR DESCRIPTION
Addresses couple of small issues that came up in today's TPM sync: clarify reserved IPs and no support for bare metal edge.