### PR TITLE
Should make the distinction with PKS tile

### DIFF
--- a/upgrading.html.md.erb
+++ b/upgrading.html.md.erb
@@ -15,7 +15,7 @@ This section describes how to upgrade the Pivotal Container Service (PKS) tile. 
     <a href="./upgrade-pks.html">Upgrade PKS</a>
   </li>
   <li>
-    <a href="./upgrade-pks-nsxt.html">Upgrade PKS</a>
+    <a href="./upgrade-pks-nsxt.html">Upgrade PKS with NSX-T</a>
   </li>
   <li>
     <a href="./maintain-uptime.html">Maintain Workload Uptime</a>


### PR DESCRIPTION
For now it is the same as the actual page title, but perhaps we name it in such a way that distinguishes between NSX-T upgrades and PKS tile upgrades.