### PR TITLE
Fixes two issues with nsxt cert commands

### DIFF
--- a/generate-certificates.html.md.erb
+++ b/generate-certificates.html.md.erb
@@ -187,7 +187,7 @@ For example:
     $ openssl req -newkey rsa:2048 -x509 -nodes \
     -keyout nsx.key -new -out nsx.crt -subj /CN=$NSX\_MANAGER\_COMMONNAME \
     -reqexts SAN -extensions SAN -config <(cat ./nsx-cert.cnf \
-     <(printf '[SAN]\nsubjectAltName=DNS:$NSX\_MANAGER\_COMMONNAME,IP:$NSX\_MANAGER\_IP\_ADDRESS')) -sha256 -days 365
+     <(printf "[SAN]\nsubjectAltName=DNS:$NSX\_MANAGER\_COMMONNAME,IP:$NSX\_MANAGER\_IP\_ADDRESS")) -sha256 -days 365
     </pre>
 
 1. Verify that the certificate looks correct and that the NSX manager IP is in the Subject Alternative Name (SAN) by running the following command:
@@ -205,7 +205,7 @@ For example:
     ```
     curl --insecure -u admin:'admin_pw' -X \
     GET https://NSX-Manager-IP-Address/api/v1/trust-management/certificates \
-    | jq '-r .results[] | select(.display_name==CERTIFICATE-NAME) | .id'
+    | jq -r '.results[] | select(.display_name==CERTIFICATE-NAME) | .id'
     ```
 
 1. Register the certificate with NSX Manager, replacing `CERTIFICATE-ID` with the certificate ID:


### PR DESCRIPTION
Critical fixes to this doc page: https://docs.pivotal.io/runtimes/pks/1-1/generate-certificates.html#certificates-super-user. Will need to be added to 1.2/Master branch as well.