### PR TITLE
Remove manual logical switch for service network, no longer needed

### DIFF
--- a/nsxt-prepare-env.html.md.erb
+++ b/nsxt-prepare-env.html.md.erb
@@ -119,9 +119,8 @@ Create the NSX-T objects (network objects, logical switches, NSX Edge, and logic
   * One for T0 ingress/egress uplink port `ls-pks-uplink`
   * One for the PKS Management Network `ls-pks-mgmt`
     <p class="note"><strong>Note</strong>: This network is required for the <a href="nsxt-topologies.html#topology-nat">NAT deployment topology</a> and <a href="nsxt-topologies.html#topology-no-nat-logical-switch">No-NAT with Logical Switch deployment topology</a>. If you are deploying the <a href="nsxt-topologies.html#topology-no-nat-virtual-switch">No-NAT with Virtual Switch topology</a>, you can skip this step.</p>
-  * One for the PKS Service Network `ls-pks-service`
 1. Attach your first NSX Logical Switch to the `tz-vlan` NSX Transport Zone.
-1. Attach your second and third NSX Logical Switches to the `tz-overlay` NSX Transport Zone.
+1. Attach your second NSX Logical Switch to the `tz-overlay` NSX Transport Zone.
 
 ###<a id='create-objects-create-nsx-edge'></a> 3.3: Create NSX Edge Objects
 


### PR DESCRIPTION
Reported via Slack: "ls-pks-service is not required since PKS will automate the creation/deletion of cluster networking. i.e. for each k8s cluster, a NSX-T logical network will be created. so you can skip the creation of ls-pks-service."