### PR TITLE
Fix indentation

### DIFF
--- a/manage-users.html.md.erb
+++ b/manage-users.html.md.erb
@@ -222,7 +222,7 @@ This step creates a `ClusterRoleBinding` for the LDAP cluster admin.
     namespace: NAMESPACE
     name: ROLE-OR-CLUSTER-ROLE-NAME
   rules:
-&#8209; apiGroups:
+  - apiGroups:
     resources: RESOURCE
     verbs: API-REQUEST-VERB
   </pre>
@@ -246,7 +246,7 @@ This step creates a `ClusterRoleBinding` for the LDAP cluster admin.
     name: ROLE-OR-CLUSTER-ROLE-BINDING-NAME
     namespace: NAMESPACE
   subjects:
-  &#8209; kind: User
+  - kind: User
     name: USERNAME
     apiGroup: rbac.authorization.k8s.io
   roleRef:


### PR DESCRIPTION
They should look like, I removed the html entities but I don't know if it's enough

```
kind: ROLE-TYPE
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  namespace: NAMESPACE
  name: ROLE-OR-CLUSTER-ROLE-NAME
rules:
- apiGroups:
  resources: RESOURCE
  verbs: API-REQUEST-VERB

```

```
kind: ROLE-BINDING-TYPE
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ROLE-OR-CLUSTER-ROLE-BINDING-NAME
  namespace: NAMESPACE
subjects:
- kind: User
  name: USERNAME
  apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: ROLE-TYPE
  name: ROLE-OR-CLUSTER-ROLE-BINDING-NAME
  apiGroup: rbac.authorization.k8s.io

```