### PR TITLE
manage-users page curl command Header typo

### DIFF
--- a/manage-users.html.md.erb
+++ b/manage-users.html.md.erb
@@ -319,7 +319,7 @@ To finish this process, the Kubernetes end user must be sent the partially compl
 
     ```
     curl 'https://PKS-API>:8443/oauth/token' -k -XPOST -H 
-    'Accept: \application/json' -d "client_id= 
+    'Accept: application/json' -d "client_id= 
     pks_cluster_client&client_secret=""&grant_type=password
     &username=UAA-USERNAME&password=UAA-PASSWORD&response_type=id_token"
     ```


### PR DESCRIPTION
```
curl 'https://PKS-API>:8443/oauth/token' -k -XPOST -H 
'Accept: \application/json' -d "client_id= 
pks_cluster_client&client_secret=""&grant_type=password
&username=UAA-USERNAME&password=UAA-PASSWORD&response_type=id_token"
```
should be
```
curl 'https://PKS-API>:8443/oauth/token' -k -XPOST -H 
'Accept: application/json' -d "client_id= 
pks_cluster_client&client_secret=""&grant_type=password
&username=UAA-USERNAME&password=UAA-PASSWORD&response_type=id_token"
```
