### PR TITLE
The position of "{" is insufficient

### DIFF
--- a/aws-prepare-env.html.md.erb
+++ b/aws-prepare-env.html.md.erb
@@ -95,7 +95,7 @@ To set up accounts with the correct permissions, create master node and worker n
 1. Copy the following policy and paste it into the policy field:
 
      ```
-          {
+     {
        "Version": "2012-10-17",
        "Statement": [
            {


### PR DESCRIPTION
In terms of "indent" policy,  the position of "{" is insufficient for "pks-master-policy"