### PR TITLE
Update wording for Service Network field

### DIFF
--- a/installing-nsx-t.html.md.erb
+++ b/installing-nsx-t.html.md.erb
@@ -40,8 +40,8 @@ Perform the following steps:
 
 1. Under **Network**, select the PKS Management Network linked to the `ls-pks-mgmt` NSX-T logical switch you created in the [Create Networks Page](vsphere-nsxt-om-config.html#create-networks) step of _Configuring Ops Manager on vSphere with NSX-T Integration_. This will provide network placement for the PKS API VM.
 1. Under **Service Network**, your selection depends on whether you are upgrading from a previous PKS version or installing an original PKS deployment.
-  * If you are deploying PKS with NSX-T for the first time, the **Service Network** field does not apply because PKS creates the service network for you during the installation process. However, the PKS tile requires you to make a selection. Therefore, select the same network you specified in the **Network** field.
-  * If you are upgrading from a previous PKS version, select the **Service Network** linked to the `ls-pks-service` NSX-T logical switch that is created by PKS during installation. The service network provides network placement for the on-demand Kubernetes cluster service instances created by the PKS broker.
+  * If you are deploying PKS with NSX-T for the first time, the **Service Network** field does not apply because PKS instructs NSX-T to create a new service network on-demand each time a new Kubernetes cluster is requested. However, the PKS tile requires you to make a selection. Therefore, select the same network you specified in the **Network** field.
+  * If you are upgrading from a previous PKS version, select the **Service Network** linked to the `ls-pks-service` NSX-T logical switch that is created by PKS during installation. The service network provides network placement for the already existing on-demand Kubernetes cluster service instances created by the PKS broker.
 1. Click **Save**.
 
 ###<a id='pks-api'></a> PKS API


### PR DESCRIPTION
The wording for the Service Network field was inaccurate, as since somewhere in PKS 1.1.x, service networks are all created on-demand for new k8s clusters as they are being provisioned. They are *not* created during tile installation, as the existing wording implies.

Added some clarifying words to the line below also, since it was not clear that in an upgrade scenario, it will place existing service instances on this network because in older versions, networks were not created for each k8s cluster at provisioning time, they were all in one network.