### PR TITLE
Update docs to indicate support for NSX-T 2.3

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -151,7 +151,7 @@ PKS v1.2.0 adds support for the following:
     <br>
     This error is the result of a change in the cURL version as part of the stemcell upgrade from Ubuntu v14.04 to v16.04. In Ubuntu 16.04, cURL comes with GnuTLS instead of OpenSSL. For a workaround, use the manual approach for generating the principle identity certificate and key as described in [NSX Manager Super User Principal Identity Certificate](generate-certificates.html#certificates-super-user) in <em>Generating and Regenerating Certificates</em>.
 * Namespace sinks do not work in environments without internet access.
-* Due to a limitation with the NSX-T v2.2 scheduler component, VMware recommends that you do not use a medium-sized load balancer at this time, even if the NSX-T edge cluster has more than two edge node VMs. This limitation is addressed in NSX-T v2.3, which PKS v1.2.x supports.
+* Due to a limitation with the NSX-T v2.2 scheduler component, VMware recommends that you do not use a medium-sized load balancer at this time, even if the NSX-T edge cluster has more than two edge node VMs. This limitation is addressed in NSX-T v2.3, which PKS v1.2.0 supports.
 * When using AWS, you must select a VM type under **Master/ETCD VM Type**, **Worker VM Type**, and **Errand VM Type** in the **Plans** section of the PKS tile in order to save a plan on the tile. You cannot leave the VM type on **Automatic**. The recommended minimum VM type is `t2.medium`.
 * Existing certificates will expire after a year. The certificates will be updated in a future release.
 * The **External Groups Whitelist** field in the **UAA** section of the PKS tile has a 4000 character limit due to the size limitation of JWT tokens.

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -41,8 +41,8 @@ This topic contains release notes for Pivotal Container Service (PKS) v1.2.x.
         <td>v0.22</td>
     </tr>
     <tr>
-        <td>NSX-T version</td>
-        <td>v2.2</td>
+        <td>NSX-T versions</td>
+        <td>v2.2, v2.3</td>
     </tr>
     <tr>
         <td>NCP version</td>
@@ -151,7 +151,7 @@ PKS v1.2.0 adds support for the following:
     <br>
     This error is the result of a change in the cURL version as part of the stemcell upgrade from Ubuntu v14.04 to v16.04. In Ubuntu 16.04, cURL comes with GnuTLS instead of OpenSSL. For a workaround, use the manual approach for generating the principle identity certificate and key as described in [NSX Manager Super User Principal Identity Certificate](generate-certificates.html#certificates-super-user) in <em>Generating and Regenerating Certificates</em>.
 * Namespace sinks do not work in environments without internet access.
-* Due to a limitation with the NSX-T v2.2 scheduler component, VMware recommends that you do not use a medium-sized load balancer at this time, even if the NSX-T edge cluster has more than two edge node VMs. This limitation is addressed in NSX-T v2.3. which PKS v1.2.x will support in the near future.
+* Due to a limitation with the NSX-T v2.2 scheduler component, VMware recommends that you do not use a medium-sized load balancer at this time, even if the NSX-T edge cluster has more than two edge node VMs. This limitation is addressed in NSX-T v2.3, which PKS v1.2.x supports.
 * When using AWS, you must select a VM type under **Master/ETCD VM Type**, **Worker VM Type**, and **Errand VM Type** in the **Plans** section of the PKS tile in order to save a plan on the tile. You cannot leave the VM type on **Automatic**. The recommended minimum VM type is `t2.medium`.
 * Existing certificates will expire after a year. The certificates will be updated in a future release.
 * The **External Groups Whitelist** field in the **UAA** section of the PKS tile has a 4000 character limit due to the size limitation of JWT tokens.

--- a/upgrade-pks-nsxt.html.md.erb
+++ b/upgrade-pks-nsxt.html.md.erb
@@ -7,7 +7,7 @@ owner: PKS
 
 This topic explains how to upgrade the Pivotal Container Service (PKS) tile for environments using vSphere with NSX-T.
 
-PKS v1.1.5 supports NSX-T v2.2 and vSphere 6.5 U2. For details, see the [VMware Product Interoperability Matrix](https://www.vmware.com/resources/compatibility/sim/interop_matrix.php) for PKS in the VMware documentation.
+PKS v1.2 supports NSX-T v2.3, which is the recommended version. To upgrade to PKS 1.2, you must upgrade from PKS v1.1.5 or later. For details, see the [VMware Product Interoperability Matrix](https://www.vmware.com/resources/compatibility/sim/interop_matrix.php) for PKS in the VMware documentation.
 
 <p class="note"><strong>Note</strong>: When you upgrade PKS on vSphere with NSX-T, workloads in your Kubernetes cluster are unavailable while the NSX Edge nodes run the upgrade. Configure NSX Edge for high availability using Active/Standby mode to avoid workload downtime. For more information, see the <a href="./nsxt-prepare-env.html#nsx-edge-ha">Configure NSX Edge for High Availability (HA)</a> section of <em>Preparing NSX-T Before Deploying PKS</em>.</p>
 


### PR DESCRIPTION
Updates RNs and NSX-T upgrade sections to indicate PKS 1.2.x supports NSX-T 2.3. Please hold off on merging until the word is official. thanks