### PR TITLE
Adds a short blurb to clarify how kubeconfig is chosen.

### DIFF
--- a/cli/index.html.md.erb
+++ b/cli/index.html.md.erb
@@ -175,7 +175,7 @@ Allows you to connect to a cluster and use kubectl
 
 ### Synopsis
 
-Run this command in order to update a kubeconfig file so you can access the cluster through kubectl
+Run this command in order to update a kubeconfig file so you can access the cluster through `kubectl`.  Uses the first location in `$KUBECONFIG` or the default location of `$HOME/.kube/config`
 
 ```
 pks get-credentials <cluster-name> [flags]
@@ -185,6 +185,12 @@ pks get-credentials <cluster-name> [flags]
 
 ```
   pks get-credentials my-cluster
+```
+
+Override `$KUBECONFIG` and store cluster config in another location:
+
+```
+KUBECONFIG=~/.kube/config-demo pks get-credentials my-cluster
 ```
 
 ### Options


### PR DESCRIPTION
This is already explained at https://docs.pivotal.io/runtimes/pks/1-0/cluster-credentials.html as well, just puts some consistency there.