### PR TITLE
Set an expectation about cluster creation time

### DIFF
--- a/create-cluster.html.md.erb
+++ b/create-cluster.html.md.erb
@@ -50,6 +50,7 @@ See the [Grant Cluster Access to a User](manage-users.html#uaa-scopes) section o
     <pre class="terminal">$ pks create-cluster my-cluster \
     --external-hostname my-cluster.example.com \
     --plan large --num-nodes 3</pre>
+  <p class="note"><strong>Note</strong>: It can take up to 30 minutes to create a cluster.</p>
 
 1. Track the cluster creation process by running `pks cluster CLUSTER-NAME`.
 Replace `CLUSTER-NAME` with the unique name for your cluster. For example:


### PR DESCRIPTION
When creating a cluster using the example command provided, the experience in the CLI does not communicate the expected time needed for cluster creation. By providing this "note", we can set an expectation that this _could_ take up to 30 minutes (this time duration was informed by a conversation with the developers on the team).