### PR TITLE
Fix formatting for script element

### DIFF
--- a/generate-nsx-pi-cert.html.md.erb
+++ b/generate-nsx-pi-cert.html.md.erb
@@ -64,7 +64,7 @@ export NODE_ID=$(cat /proc/sys/kernel/random/uuid)
 
 1. On the same Linux VM, run the following commands to register the certificate with NSX Manager:
     <pre class="terminal">
-    cert_request=$(cat &lt;&lt;END
+    cert_request=$(cat <<END
       {
         "display_name": "$PI_NAME",
         "pem_encoded": "$(awk '{printf "%s\\n", $0}' $NSX_SUPERUSER_CERT_FILE)"
@@ -93,7 +93,7 @@ export NODE_ID=$(cat /proc/sys/kernel/random/uuid)
 
 1. Register the principal identity with NSX Manager by running the following commands:
     <pre class="terminal">
-    pi_request=$(cat &lt;&lt;END
+    pi_request=$(cat <<END
       {
         "display_name": "$PI_NAME",
         "name": "$PI_NAME",


### PR DESCRIPTION
Addresses formatting issue here: https://docs.pivotal.io/runtimes/pks/1-2/generate-nsx-pi-cert.html#certificate-super-user-ui.

Step 4 script displays as "pem_encoded": "$(awk '{printf "%s\n", $0}' $NSX_SUPERUSER_CERT_FILE)" when it should be "%s\\\n"   (it needs to show 1 more ‘\’ as per the source). The way it displays in Option B is correct.

Fixed the other one (although not causing a problem) for consistency. 

Should also go into Master.