### PR TITLE
Update info on no-proxy property with wildcards

### DIFF
--- a/installing-pks-vsphere.html.md.erb
+++ b/installing-pks-vsphere.html.md.erb
@@ -68,7 +68,7 @@ If your environment includes HTTP or HTTPS proxies, configuring PKS to use these
       <img src="images/networking-https-proxy.png" alt="Networking pane configuration" width="325">
   1. Under **HTTP Proxy URL**, enter the URL of your HTTP/HTTPS proxy endpoint. For example, `http://myproxy.com:1234`.
   1. (Optional) If your proxy uses basic authentication, enter the username and password under **HTTP Proxy Credentials**.
-  1. Under **No Proxy**, enter the service network CIDR where your PKS cluster is deployed. List any additional IP addresses that should bypass the proxy.
+  1. Under **No Proxy**, enter the service network CIDR where your PKS cluster is deployed. List any additional IP addresses or domain names that should bypass the proxy. Domain names with wildcards are accepted (e.g.: *.foo.bar, .foo.bar). Keep in mind that some jobs in the VMs might accept '*.foo' as wildcard and some others (like Docker) only accept '.foo' as wildcard.
     <p class="note"><strong>Note</strong>: By default, the <code>.internal</code>, <code>10.100.0.0/8</code>, and <code>10.200.0.0/8</code> IP address ranges are not proxied. This allows internal PKS communication.</p>
 1. Under **Allow outbound internet access from Kubernetes cluster vms (IaaS-dependent)**, ignore the **Enable outbound internet access** checkbox.
 1. Click **Save**.

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -6,3 +6,7 @@ owner: PKS
 <strong><%= modified_date %></strong>
 
 This topic contains release notes for Pivotal Container Service (PKS) v1.3.x.
+
+
+Bug fixes:
+No proxy property for vSphere now accepts wildcard domains (e.g.: *.example.com, .example.com). Check <a href="./installing-pks-vsphere.html#networking">Installing PKS on vSphere</a> for more information.


### PR DESCRIPTION
Added wildcard information for the no-proxy property. including the fact that some  jobs accept `*.` as wildcard and some others `.` to prefix domains with wildcards.

Perhaps we should recommend to type both in case the user is not sure? Example: always type `*.foo.bar` and `.foo.bar` if you want to have a wildcard for `whatever.foo.bar`

Signed-off-by: Greg Patricio <gpatricio@pivotal.io>