### PR TITLE
Frontend config only allows single port or range

### DIFF
--- a/gcp-api-load-balancer.html.md.erb
+++ b/gcp-api-load-balancer.html.md.erb
@@ -48,8 +48,14 @@ To create a load balancer using GCP, perform the following steps:
       1. Enter a name for your reserved IP address. For example, `pks-api-ip`. GCP assigns a static IP address that appears next to the name.
       1. (Optional) Enter a description.
       1. Click **Reserve**.
-   * Under **Ports**, enter `8443` and `9021`. Your external load balancer forwards traffic to the PKS control plane VM using the UAA endpoint on port 8443 and the PKS API endpoint on port 9021.
+   * Under **Port**, enter `9021`. Your external load balancer forwards traffic to the PKS control plane VM using the UAA endpoint on port 8443 and the PKS API endpoint on port 9021.
    * Click **Done**.
+   * Click ** New Frontend IP and Port **.
+      1. Enter a name for the frontend IP-port mapping such as `pks-api-uaa`
+      1. (Optional) Add a description
+      1. Under ** IP ** select the same static IP GCP assigned in the previous step.
+      1. Under **Port**, enter `8443`.
+      1. Click **Done**.
 
 1. Click **Review and finalize** to review your load balancer configuration.
 


### PR DESCRIPTION
When configuring the frontend for the LB on GCP the latest version of the console only allows a single port or a range to be specified. Each IP-port must be separately mapped.