### PR TITLE
Adding BOSH Director VM to requirements for all IaaS's

### DIFF
--- a/aws-requirements.html.md.erb
+++ b/aws-requirements.html.md.erb
@@ -9,7 +9,7 @@ This topic describes the prerequisites and resource requirements for installing 
 
 ##<a id='resources'></a> Resource Requirements
 
-Installing PKS deploys the following two virtual machines (VMs):
+Installing PKS deploys the following virtual machines (VMs):
 
 <table>
   <tr>
@@ -29,6 +29,12 @@ Installing PKS deploys the following two virtual machines (VMs):
     <td>1</td>
     <td>8 GB</td>
     <td>160 GB</td>
+  </tr>
+  <tr>
+    <td>BOSH Director</td>
+    <td>2</td>
+    <td>8 GB</td>
+    <td>16 GB</td>
   </tr>
 </table>
 

--- a/gcp-requirements.html.md.erb
+++ b/gcp-requirements.html.md.erb
@@ -9,7 +9,7 @@ This topic describes the prerequisites and resource requirements for installing 
 
 ##<a id='resources'></a> Resource Requirements
 
-Installing PKS deploys the following two virtual machines (VMs):
+Installing PKS deploys the following virtual machines (VMs):
 
 <table>
   <tr>
@@ -29,6 +29,12 @@ Installing PKS deploys the following two virtual machines (VMs):
     <td>1</td>
     <td>8 GB</td>
     <td>160 GB</td>
+  </tr>
+  <tr>
+    <td>BOSH Director</td>
+    <td>2</td>
+    <td>8 GB</td>
+    <td>16 GB</td>
   </tr>
 </table>
 

--- a/vsphere-nsxt-requirements.html.md.erb
+++ b/vsphere-nsxt-requirements.html.md.erb
@@ -52,7 +52,7 @@ Deploying NSX-T requires the additional following component versions:
 
 ###<a id='pks'></a> PKS
 
-Installing PKS deploys the following two virtual machines (VMs):
+Installing PKS deploys the following virtual machines (VMs):
 
 <table>
   <tr>
@@ -72,6 +72,12 @@ Installing PKS deploys the following two virtual machines (VMs):
     <td>1</td>
     <td>8 GB</td>
     <td>160 GB</td>
+  </tr>
+  <tr>
+    <td>BOSH Director</td>
+    <td>2</td>
+    <td>8 GB</td>
+    <td>16 GB</td>
   </tr>
 </table>
 

--- a/vsphere-requirements.html.md.erb
+++ b/vsphere-requirements.html.md.erb
@@ -33,7 +33,7 @@ PKS on vSphere supports the following vSphere component versions:
 
 ##<a id='resources'></a> Resource Requirements
 
-Installing PKS deploys the following two virtual machines (VMs):
+Installing PKS deploys the following virtual machines (VMs):
 
 <table>
   <tr>
@@ -53,6 +53,12 @@ Installing PKS deploys the following two virtual machines (VMs):
     <td>1</td>
     <td>8 GB</td>
     <td>160 GB</td>
+  </tr>
+  <tr>
+    <td>BOSH Director</td>
+    <td>2</td>
+    <td>8 GB</td>
+    <td>16 GB</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Addresses doc bug sent to me via email. BOSH Director VM needs to be included in the list of VMs that get deployed as part of PKS. 

This PR also applies to the Master branch.

thanks