### PR TITLE
Update release-notes.html.md.erb

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -134,4 +134,8 @@ _Installing PKS on vSphere_ for more information.
 
 ### <a id="v1.3.0-beta1-known-issues"></a>Known Issues
 
-There are no known issues.
+PKS v1.3.0-beta.1 has the following known issues
+* [CVE-2018-15759](https://pivotal.io/security/cve-2018-15759) - This CVE contains an insecure method of verifying credentials. A remote unauthenticated malicious user may make many requests to the service broker with a series of different credentials, allowing them to infer valid credentials and gain access to perform broker operations.
+* [CVE-2018-1002105](https://pivotal.io/security/cve-2018-1002105) - Where users are able to establish a connection through the Kubernetes API server to backend servers, then send arbitrary requests over the same connection directly to the backend, authenticated with the Kubernetes API server’s TLS credentials used to establish the backend connection.
+
+Because of these two CVE issues we reccomend PKS 1.3.0-beta.1 is for testing purposes only.  This should not be deployed into production environments 


### PR DESCRIPTION
Update Patch release notes for 1.3.0-beta.1 to include details about the two CVE's that are not resolved in the build we are pushing to PivNet.  We want to clearly indicate these two CVEs and inform users that due to the CVE limitations this patch is for testing purposes only and should not be deployed into production environments 