### PR TITLE
Add docker version to RNs for 1.3

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -48,6 +48,10 @@ This topic contains release notes for Pivotal Container Service (PKS) v1.3.x.
         <td>NCP version</td>
         <td>v2.3.1</td>
     </tr>
+    <tr>
+        <td>Docker version ([CFCR](https://github.com/cloudfoundry-incubator/docker-boshrelease/))</td>
+        <td>v18.06.1-ce</td>
+    </tr>
 </table>
 
 ### <a id="v1.3.0-beta1-iaas"></a>Feature Support by IaaS


### PR DESCRIPTION
The docker component is managed by the CFCR team via the docker-boshrelease component: https://github.com/cloudfoundry-incubator/docker-boshrelease/. PKS 1.3 will be shipped with Docker v18.06.1-ce.