### PR TITLE
Add docker v to 1.2 rns

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -48,6 +48,10 @@ This topic contains release notes for Pivotal Container Service (PKS) v1.2.x.
         <td>NCP version</td>
         <td>v2.3.1</td>
     </tr>
+    <tr>
+        <td>Docker version</td>
+        <td>17.12.1-ce ([CFCR v0.24.0](https://docs-cfcr.cfapps.io/overview/release-notes/#component-versions))</td>
+    </tr>
 </table>
 
 ### <a id="v1.2.4-iaas"></a>Feature Support by IaaS


### PR DESCRIPTION
Docker is part of CFCR: https://docs-cfcr.cfapps.io/overview/release-notes/
PKS packages CFCR. The latest release of Docker supported by CFCR  is 17.12.1-ce (CFCR v0.24.0).
