### PR TITLE
Fix vSAN w/ shared datastore case + NFS language

### DIFF
--- a/vsphere-persistent-storage.html.md.erb
+++ b/vsphere-persistent-storage.html.md.erb
@@ -39,7 +39,7 @@ PVs can be used with two types of Kubernetes workloads:
 With PKS on vSphere, you can choose one of two storage options to support stateful apps:
 
 * vSAN datastores
-* VMFS over Network File Share (NFS), Internet Small Computer Systems Interface (iSCSI), or fiber channel (FC) datastores
+* Network File Share (NFS) or VMFS over Internet Small Computer Systems Interface (iSCSI), or fiber channel (FC) datastores
 
 Refer to the [vSAN documentation](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.virtualsan.doc/GUID-AEF15062-1ED9-4E2B-BA12-A5CE0932B976.html) and the [VMFS documentation](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.storage.doc/GUID-5EE84941-366D-4D37-8B7B-767D08928888.html?hWord=N4IghgNiBcIG4FsBmBnEBfIA) for more information about these storage options.
 
@@ -55,7 +55,7 @@ The table below summarizes PKS support for PVs in Kubernetes when deployed on vS
   <tr>
     <th>Storage Mechanism</th>
     <th>Supported vSAN datastores</th>
-    <th>Supported VMFS over NFS/iSCSI/FC datastores</th>
+    <th>Supported NFS or VMFS over iSCSI/FC datastores</th>
   </tr>
   <tr>
     <td><ul><li>Single vSphere compute cluster with a cluster-wide datastore</li><li>Single AZ using a resource pool</li></ul></td>
@@ -100,7 +100,7 @@ This topology has the following failover scenarios:
 
 ### <a id='single-vmfs'></a>Single vSphere Compute Cluster with a VMFS Datastore
 
-The following diagram illustrates a vSphere environment with a single vSphere compute cluster and a shared datastore using VMFS over NFS, iSCSI, or FC. For this topology, PKS supports both static and dynamic PV provisioning. Dynamic PV provisioning is recommended.
+The following diagram illustrates a vSphere environment with a single vSphere compute cluster and a shared datastore using NFS or VMFS over iSCSI, or FC. For this topology, PKS supports both static and dynamic PV provisioning. Dynamic PV provisioning is recommended.
 
   <img src="images/vsphere/vsphere-pv-a2-vmfs.png" alt="Single vSphere compute cluster with shared VMFS datastore">
 
@@ -135,7 +135,7 @@ One or more AZs can be instantiated. Each AZ is mapped to a vSphere compute clus
 
 <p class="note"><strong>Note</strong>: PKS does not support PV provisioning with this topology.</p>
 
-The following diagram illustrates a vSphere environment with multiple vSphere compute clusters with VMFS over NFS, iSCSI, or FC local datastores.
+The following diagram illustrates a vSphere environment with multiple vSphere compute clusters with NFS or VMFS over iSCSI, or FC local datastores.
 
   <img src="images/vsphere/vsphere-pv-b2-vmfs.png" alt="Multi vSphere compute clusters (Multi AZs) with local VMFS datastore">
 
@@ -143,17 +143,15 @@ In this topology, multiple vSphere compute clusters are used to host all Kuberne
 
 One or more AZs can be instantiated. Each AZ is mapped to a vSphere compute cluster. The AZ is bound to a failure domain which is typically the physical rack where the compute cluster is hosted.
 
-## <a id='vsphere-pv-c'></a>Multiple vSphere Compute Clusters with Shared Datastore
+## <a id='vsphere-pv-c'></a>Multiple vSphere Compute Clusters with Shared Datastores
 
 This section describes PKS support for vSphere environments with multiple compute clusters with datastores shared across all vSphere compute clusters.
 
-### <a id='multiple-shared-vsan'></a>Multiple vSphere Compute Clusters with Shared vSAN Datastores
-
-<p class="note"><strong>Note</strong>: PKS does not support PV provisioning with this topology.</p>
+### <a id='multiple-shared-vsan'></a>Multiple vSphere Compute Clusters with Local vSAN Datastores and at least one Shared VMFS/NFS Datastore
 
 With this topology, each vSAN datastore is only visible from each vSphere compute cluster. It is not possible to have a vSAN datastore shared across all vSphere compute clusters.
 
-You can insert a shared NFS, iSCSI, or FC datastore across all vSAN-based vSphere compute clusters to support both static and dynamic PV provisiong.
+You can insert a shared NFS, iSCSI (VMFS), or FC (VMFS) datastore across all vSAN-based vSphere compute clusters to support both static and dynamic PV provisiong.
 
 Refer to the following diagram:
 
@@ -165,7 +163,7 @@ The following diagram illustrates a vSphere environment with multiple compute cl
 
   <img src="images/vsphere/vsphere-pv-c2-vmfs.png" alt="Multi vSphere compute clusters (Multi AZs) with Shared VMFS datastore">
 
-In this topology, multiple vSphere compute clusters are used to host all Kubernetes clusters. A unique shared datastore that uses VMFS over NFS, iSCSI, or FC is used across all compute clusters. In the above diagram, this datastore is labeled **Shared Datastore1**.
+In this topology, multiple vSphere compute clusters are used to host all Kubernetes clusters. A unique shared datastore that uses NFS, or VMFS over iSCSI/FC is used across all compute clusters. In the above diagram, this datastore is labeled **Shared Datastore1**.
 
 One or more AZs can be instantiated. Each AZ is mapped to a compute cluster. The AZ is bound to a failure domain which is typically the physical rack where the compute cluster is hosted.
 


### PR DESCRIPTION
The section Multiple vSphere Compute Clusters with Shared vSAN Datastores was incorrectly named/described and did not match its actual diagram which was correct and would in-fact allow dynamic PVs to work, as the table higher up on the same page actually described.

Fixed the section name, fixed the language, removed the warning that this topology does not work with persistent volumes.

Secondly, "VMFS over NFS" is not an accurate phrase. NFS is NFS, which is separate to VMFS. 
Only FC/iSCSI use VMFS, while NFS is its own thing that vSphere also functions with, so I have corrected all instances of referring to NFS as a type of VMFS.