### PR TITLE
Update warning on 2 topologies

### DIFF
--- a/vsphere-persistent-storage.html.md.erb
+++ b/vsphere-persistent-storage.html.md.erb
@@ -121,7 +121,7 @@ This section describes PKS support for PVs in an environment with multiple vSphe
 
 ### <a id='multiple-vsan'></a>Multiple vSphere Compute Clusters with Local vSAN Datastores
 
-<p class="note"><strong>Note</strong>: PKS does not support PV provisioning with this topology.</p>
+<p class="note"><strong>Note</strong>: PKS does not support **Dynamic** PV provisioning with this topology. **Static** PV provisioning only.</p>
 
 The following diagram illustrates a vSphere environment with multiple vSphere compute clusters with vSAN datastores that are local to each compute cluster.
 
@@ -133,7 +133,7 @@ One or more AZs can be instantiated. Each AZ is mapped to a vSphere compute clus
 
 ### <a id='multiple-vmfs'></a>Multiple vSphere Compute Clusters with Local VMFS Datastores
 
-<p class="note"><strong>Note</strong>: PKS does not support PV provisioning with this topology.</p>
+<p class="note"><strong>Note</strong>: PKS does not support **Dynamic** PV provisioning with this topology. **Static** PV provisioning only.</p>
 
 The following diagram illustrates a vSphere environment with multiple vSphere compute clusters with NFS or VMFS over iSCSI, or FC local datastores.
 


### PR DESCRIPTION
Clarified that Static PV provisioning does work in 2 topologies, even though Dynamic does not. The diagrams already reflect this but the text did not.