### PR TITLE
Updates to 1.2.5 and 1.2.6 RNs

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -30,7 +30,7 @@ This topic contains release notes for Pivotal Container Service (PKS) v1.2.x.
     </tr>
     <tr>
         <td>Stemcell version</td>
-        <td>v97.42</td>
+        <td>v97.43</td>
     </tr>
     <tr>
         <td>Kubernetes version</td>
@@ -42,7 +42,7 @@ This topic contains release notes for Pivotal Container Service (PKS) v1.2.x.
     </tr>
     <tr>
         <td>NSX-T versions</td>
-        <td>v2.2, v2.3.0.2</td>
+        <td>v2.2, v2.3.0.2, v2.3.1</td>
     </tr>
     <tr>
         <td>NCP version</td>
@@ -122,6 +122,7 @@ For more information, see [Upgrading PKS](upgrade-pks.html) and [Upgrading PKS w
 
 PKS v1.2.6 adds support for the following:
 
+- Updates Xenial Stemcell v97.43.
 - **Fix**: PKS v1.2.4 and v1.2.5 introduced a bug that could cause the master nodes of clusters to reach 100% of CPU and memory utilization and become unresponsive when syslog was enabled in the PKS tile. This issue is resolved.
 
 ## <a id="v1.2.5"></a>v1.2.5
@@ -159,7 +160,7 @@ PKS v1.2.6 adds support for the following:
     </tr>
     <tr>
         <td>NSX-T versions</td>
-        <td>v2.2, v2.3.0.2</td>
+        <td>v2.2, v2.3.0.2, v2.3.1</td>
     </tr>
     <tr>
         <td>NCP version</td>


### PR DESCRIPTION
Stemcell for 1.2.6 is 97.43 (https://github.com/pivotal-cf/p-pks-integrations/compare/v1.2.5-build.4...v1.2.6-build.2). NSX-T 2.3.1 is supported in 1.2.5 and 1.2.6 (https://docs.vmware.com/en/VMware-NSX-T-Data-Center/2.3.1/rn/VMware-NSX-T-Data-Center-231-Release-Notes.html). 