### PR TITLE
Updates to network profiles documentation

### DIFF
--- a/network-profiles-define.html.md.erb
+++ b/network-profiles-define.html.md.erb
@@ -56,7 +56,7 @@ np_customer_B.json
         "fip_pool_ids": [
             "e50e8f6e-1a7a-45dc-ad49-3a607baa7fa2"
         ],
-    	"pod_routable": enabled,
+    	"pod_routable": true,
     	"pod_ip_block_ids": [
       		"ebe78a74-a5d5-4dde-ba76-9cf4067eee55",
       		"ebe78a74-a5d5-4dde-ba76-9cf4067eee56"
@@ -78,7 +78,7 @@ Parameter 				| Description
 `parameters`    		| One or more name-value pairs.
 `lb_size`	  			| Size of the NSX-T load balancer deployed with the Kubernetes cluster: `small`, `medium`, or `large`.
 `pod_ip_block_ids`		| UUID of the IP block from NSX Manager; one or more, comma-separated.
-`pod_routable`  		| Set to `enabled` if the custom Pods IP Block is a routable subnet.
+`pod_routable`  		| Include this parameter and set the value to `true` if the custom Pods IP Block is a routable subnet.
 `master_vms_nsgroup_id` | UUID of an NSGroup.
 `fip_pool_ids`			| UUID of a floating IP pool.
 `pod_subnet_prefix`     | Prefix size of the custom Pods IP Block subnet.
@@ -180,7 +180,7 @@ For example, the following network profile defines routable pod addresses from t
     "description": "Network profile with small load balancer and two routable pod networks",
     "name": "small-routable-pod",
     "parameters": {
-      "pod_routable": enabled,
+      "pod_routable": true,
       "pod_ip_block_ids": [
         "ebe78a74-a5d5-4dde-ba76-9cf4067eee55",
         "ebe78a74-a5d5-4dde-ba76-9cf4067eee56"
@@ -304,7 +304,7 @@ np_customer_A.json
     "lb_size": "medium"
     "t0_router_id": "82e766f7-67f1-45b2-8023-30e2725600ba"
     "fip_pool_ids": "8ec655f-009a-79b7-ac22-40d37598c0ff"
-    "pod_routable": enabled
+    "pod_routable": true
     "pod_ip_block_ids": "fce766f7-aaf1-49b2-d023-90e272e600ba"
   }
 }
@@ -319,10 +319,10 @@ np_customer_B.json
     "lb_size": "small"
     "t0_router_id": "a4e766cc-87ff-15bd-9052-a0e2425612b7"
     "fip_pool_ids": "4ec625f-b09b-29b4-dc24-10d37598c0d1"
-    "pod_routable": enabled
+    "pod_routable": true
     "pod_ip_block_ids": "91e7a3a1-c5f1-4912-d023-90e272260090"
   }
 }
 ```
 
-<p class="note"><strong>Note</strong>: The difference between NAT and No-NAT for a tenant T0 router is the <code>pod_routable</code> parameter. If enabled, the custom Pods IP Block subnet is routable and therefore No-NAT. If <code>pod_routable</code> is not enabled, the custom Pods IP Block is not routable and the tenant Tier-0 is deployed in NAT-mode.</p>
+<p class="note"><strong>Note</strong>: The difference between NAT and No-NAT for a tenant T0 router is the <code>pod_routable</code> parameter. If <code>pod_routable</code> is set to `true`, the custom Pods IP Block subnet is routable and therefore No-NAT. If <code>pod_routable</code> is not present or is set to `false`, the custom Pods IP Block is not routable and the tenant Tier-0 is deployed in NAT-mode.</p>

--- a/network-profiles.html.md.erb
+++ b/network-profiles.html.md.erb
@@ -5,10 +5,22 @@ owner: PKS
 
 <strong><%= modified_date %></strong>
 
-This topic describes how to create and use network profiles for Kubernetes clusters
+Network profiles let you customize NSX-T configuration parameters at the time of cluster creation. 
+
+Network profiles are defined using JSON and created using the PKS CLI. Once the network profile is defined and created, it can be referenced by the PKS administrator at the time of cluster creation.
+
+For more information about network profiles and how to define them, see [Defining Network Profiles](network-profiles-define.html).
+
+This topic assumes that the network profile JSON file has been defined, and describes how to create and use network profiles for Kubernetes clusters
 provisioned with Pivotal Container Service (PKS) on vSphere with NSX-T integration.
 
-To define a network profile using JSON, see [Defining Network Profiles](network-profiles-define.html).
+## <a id='workflow'></a> Workflow for Implementing Network Profiles
+
+The workflow for implementing a network profile is as follows:
+
+* [Define a Network Profile](./network-profiles-define.html) using JSON
+* [Create a Network Profile](#create-profile) using the PKS CLI
+* [Create a Cluster with a Network Profile](#create-cluster) using the PKS CLI
 
 ## <a id='permissions'></a> Required Permissions
 


### PR DESCRIPTION
This PR reverts the pod_routable param value from "enabled" to "true" because the change in the code was never actually merged, it was only shown that way during the TOI. Also, added some language to the Using Network Profiles topic to briefly explain what they are since the topic was split into two (this change is based on customer feedback). These updates apply to the 1.2 branch and the master branch. thanks