### PR TITLE
public ip vm_extensions as ignored for azure

### DIFF
--- a/installing-pks-azure.html.md.erb
+++ b/installing-pks-azure.html.md.erb
@@ -95,8 +95,7 @@ To configure networking, do the following:
 1. (Optional) Enter values for **Kubernetes Pod Network CIDR Range** and **Kubernetes Service Network CIDR Range**. 
 	* Ensure that the CIDR ranges do not overlap and have sufficient space for your deployed services.
 	* Ensure that the CIDR range for the **Kubernetes Pod Network CIDR Range** is large enough to accommodate the expected maximum number of pods.
-1. (Optional) If you do not use a NAT instance, select **Allow outbound internet access from Kubernetes cluster vms (IaaS-dependent)**.
-Enabling this functionality assigns external IP addresses to VMs in clusters.
+1. Under **Allow outbound internet access from Kubernetes cluster vms (IaaS-dependent)**, ignore the **Enable outbound internet access** checkbox. This option is ignored when deploying a cluster due to an incompatibility between public dynamic ips (provided by bosh) and Load Balancers on Azure.
 
 1. Click **Save**.
 


### PR DESCRIPTION
This property is going to be ignored when installing PKS on azure.

The updated should be part of 1.3.x documentation

[#163231314]