### PR TITLE
Document limitations about backup&restore pks clusters

### DIFF
--- a/backup-and-restore.html.md.erb
+++ b/backup-and-restore.html.md.erb
@@ -5,24 +5,27 @@ owner: PKS
 
 <strong><%= modified_date %></strong>
 
-This section describes how to back up and restore the Pivotal Container Service (PKS) control plane.
-PKS uses the Cloud Foundry [BOSH Backup and Restore](https://docs.cloudfoundry.org/bbr/index.html) framework to back up and restore the PKS control plane.
+This section describes how to back up and restore the Pivotal Container Service (PKS) control plane and single master PKS clusters.
+PKS uses the Cloud Foundry [BOSH Backup and Restore](https://docs.cloudfoundry.org/bbr/index.html) framework to back up and restore the PKS control plane and single master clusters.
 
-The PKS control plane includes the following components:
+BBR backs up the following PKS control plane components:
 
 * UAA MySQL database
 * PKS API MySQL database
 
-BOSH Backup and Restore (BBR) backs up the PKS control plane components.
-BBR does not back up cluster data or deployed applications.
+BBR backs up the following single master cluster components:
 
-BBR orchestrates triggering the backup or restore process on the PKS BOSH deployment,
-and transfers the backup artifacts to and from the PKS BOSH deployment.
+* Etcd database
+
+BBR orchestrates triggering the backup or restore process on the BOSH deployment,
+and transfers the backup artifacts to and from the BOSH deployment.
 
 For more information about installing and using BBR, see the following topics:
 
 * [Installing BOSH Backup and Restore](bbr-install.html)
 * [Backing up the PKS Control Plane](bbr-backup.html)
 * [Restoring the PKS Control Plane](bbr-restore.html).
+* [Backing up the Single Master Cluster](bbr-backup-cluster.html).
+* [Restoring the Single Master Cluster](bbr-restore-cluster.html).
 
 * For information about troubleshooting BBR, see [BBR Logging](bbr-logging.html).

--- a/bbr-backup-cluster.html.md.erb
+++ b/bbr-backup-cluster.html.md.erb
@@ -12,6 +12,9 @@ To perform a restore of a single master cluster with BBR, see the instructions i
 
 <p class="note"><strong>Note:</strong> This process does not back up the contents of disks that are attached to nodes.</p>
 
+## <a id='limitations'></a> Limitations
+BBR only backs up and restores the cluster etcd data. This includes the cluster deployed workloads. Persistent volumes and other IAAS resources, e.g. load balancers of workloads, are not backed up. Backup and restore for clusters deployed on vSphere with NSX-T is not yet supported.
+
 ## <a id='prereqs'></a> Prerequisites
 
 Before using the result of the backup to restore to a destination environment, verify that the

--- a/bbr-restore-cluster.html.md.erb
+++ b/bbr-restore-cluster.html.md.erb
@@ -16,6 +16,8 @@ To perform a back up of a single master cluster with BBR, see the instructions i
 is stopped in the API server. During this process, only currently deployed clusters function, and
 you cannot create new workloads.</p>
 
+<p class="note warning"><strong>Warning:</strong> BBR only backs up and restores the cluster etcd data. This includes the cluster deployed workloads. Persistent volumes and other IAAS resources, e.g. load balancers of workloads, are not backed up and restored. Backup and restore for clusters deployed on vSphere with NSX-T is not yet supported.</p>
+
 ## <a id="compatibility"></a> Compatibility of Restore
 
 This section describes the restrictions on a backup artifact for it to be restorable to another


### PR DESCRIPTION
Hi!

Platform Recovery team here. This PR adds documentation on limitations about backup and restore of single master clusters. We also modified the main page of the backup restore to add links to newly created pages.

Thanks!
@pivotal-cf/pcf-backup-and-restore 