### PR TITLE
PKS 1.3 accepts * as a no_proxy field

### DIFF
--- a/proxies.html.md.erb
+++ b/proxies.html.md.erb
@@ -52,7 +52,7 @@ To configure a global HTTP proxy for all outgoing HTTP/HTTPS traffic from the Ku
 	POD-NETWORK-IP-BLOCK-CIDR
 	```
 
-	The **No Proxy** field in the PKS tile does not accept wildcard domain notation, such as `*.docker.io` and `*.docker.com`. You must specify the exact IP or FQDN to bypass the proxy. Typical FQDNs to include in the **No Proxy** field include the following common Docker repositories:
+	Typical FQDNs to include in the **No Proxy** field include the following common Docker repositories:
     - `registry-1.docker.io`
     - `auth.docker.io`
     - `production.cloudflare.docker.com`


### PR DESCRIPTION
cc @carlo-colombo 