### PR TITLE
Fix quote style and first sentence

### DIFF
--- a/azure-om-config.html.md.erb
+++ b/azure-om-config.html.md.erb
@@ -6,7 +6,7 @@ owner: Ops Manager
 <strong><%= modified_date %></strong>
 <html class="list-style-none"></html>
 
-This topic describes how to configure Ops Manager to deploy the BOSH Director for Pivotal Container Service (PKS) on Amazon Web Services (Azure).
+This topic describes how to configure Ops Manager to deploy the BOSH Director for Pivotal Container Service (PKS) on Azure.
 
 <p class="note"><strong>Note</strong>: You can also perform the procedures in
 this topic using the Ops Manager API. For more information, see the
@@ -369,7 +369,7 @@ GH12345678ABCDEFGH12345678ABCDEFGH12345678...
 1. Click **Save**. To view your saved Director password, click the **Credentials** tab.
 <% end %>
 
-## <a id=`bosh_dns`></a>Step 7: BOSH DNS Config Page 
+## <a id='bosh_dns'></a>Step 7: BOSH DNS Config Page 
 
 <ol>
 <li>Select <strong>BOSH DNS Config</strong>.


### PR DESCRIPTION
This is causing a problem for our consumption of the docs:
## <a id=`bosh_dns`></a>Step 7: BOSH DNS Config Page
Wrong style of quotes. Changed to the use proper single quotes.
Also, the title is Azure but the first sentence says AWS. Fixed.
Applies to 1.3 branch as well.
Thanks