### PR TITLE
Adding warning about special chars in cluster name

### DIFF
--- a/create-cluster.html.md.erb
+++ b/create-cluster.html.md.erb
@@ -61,6 +61,7 @@ See the [Grant PKS Access to a User](manage-users.html#uaa-user) section of _Man
   </pre>
   Replace the placeholder values in the command as follows:
   * `CLUSTER-NAME`: Enter a unique name for your cluster.
+  <p class="note"><strong>WARNING</strong>: The CLUSTER-NAME must not contain special characters such as `&`. The PKS CLI does not validate the presence of special characters in the CLUSTER-NAME string, but the creation of the cluster will fail if one or more special characters are present.</p>
   * `HOSTNAME`: Enter an external hostname for your cluster. You can use any fully qualified
 domain name (FQDN) or IP address you own. For example, `my-cluster.example.com` or `10.0.0.1`.
 If you created an external load balancer, use its IP address.


### PR DESCRIPTION
applies to 1.3, 1.2, and 1.4/master branches, thanks