### PR TITLE
Add PKS mgmt plane node to reserved IPs list

### DIFF
--- a/nsxt-prepare-env.html.md.erb
+++ b/nsxt-prepare-env.html.md.erb
@@ -63,7 +63,9 @@ For example, /20 allows up to 16 Kubernetes clusters to be created.</p>
 
 ###<a id='reserved-ip-blocks'></a>Reserved IP Blocks
 
-Do not use any of the IP blocks listed in this section for pods or nodes.
+The PKS Management Plane must not use the use 172.17.0.0/16 subnet. This restriction applies to all virtual machines (VMs) deployed during the PKS installation process, including the PKS API server (PKS Control Plane), Ops Manager, BOSH Director, and Harbor Registry.
+
+In addition, do not use any of the IP blocks listed below for Kubernetes master or worker node VMs, or for Kubernetes pods.
 If you create Kubernetes clusters with any of the blocks listed below, the Kubernetes worker nodes cannot reach Harbor or internal Kubernetes services.
 
 The Docker daemon on the Kubernetes worker node uses the subnet in the following CIDR range.


### PR DESCRIPTION
Customer placed BOSH in 172.17.31.0/24 and could not deploy clusters. PKS mgmt plane subnet MUST not use 172.17.0.0/16 subnet.

Also applies to 1.2 and 1.4/master.