### PR TITLE
Rearrange the steps to reflect the correct workflow

### DIFF
--- a/gcp-cluster-load-balancer.html.md.erb
+++ b/gcp-cluster-load-balancer.html.md.erb
@@ -69,19 +69,7 @@ Perform the following steps to configure the backend of the load balancer:
   1. Specify any other configuration options you require and click **Update** to complete backend configuration.
   <p class="note"><strong>Note</strong>: For clusters with multiple master node VMs, health checks on port 8443 are recommended.</p>
 
-###<a id="access"></a> Step 4: Access the Cluster
-
-Perform the following steps to complete cluster configuration:
-
-1. From your local workstation, run `pks get-credentials CLUSTER-NAME`.
-This command creates a local `kubeconfig` that allows you to manage the cluster.
-For more information about the `pks get-credentials` command, see [Retrieving Cluster Credentials and Configuration](cluster-credentials.html).
-
-1. Run `kubectl cluster-info` to confirm you can access your cluster using the Kubernetes CLI.
-
-See [Managing <%= vars.product_short %>](managing.html) for information about checking cluster health and viewing cluster logs.
-
-###<a id="tag"></a> Step 5: Create a Network Tag
+###<a id="tag"></a> Step 4: Create a Network Tag
 
 Perform the following steps to create a network tag:
 
@@ -92,7 +80,7 @@ Perform the following steps to create a network tag:
 1. Click in the **Network tags** field and type a human-readable name in lower case letters. Press **Enter** to create the network tag.
 1. Scroll to the bottom of the screen and click **Save**.
 
-###<a id="firewall"></a> Step 6: Create Firewall Rules
+###<a id="firewall"></a> Step 5: Create Firewall Rules
 
 Perform the following steps to create firewall rules:
 
@@ -109,7 +97,7 @@ Perform the following steps to create firewall rules:
 1. Specify any other configuration options you require and click **Done** to complete frontend configuration.
 1. Click **Create**.
 
-## <a id="reconfigure"></a>Reconfigure Load Balancer
+### <a id="reconfigure"></a>Step 6: Reconfigure Load Balancer
 
 If Kubernetes master node VMs are recreated for any reason, you must reconfigure your cluster load balancers to point to the new master VMs.
 For example, after a stemcell upgrade, BOSH recreates the VMs in your deployment.
@@ -124,3 +112,16 @@ To reconfigure your GCP cluster load balancer to use the new master VMs, do the 
 1. Click **Select existing instances**.
 1. Select the new master VM IDs from the dropdown. Use the VM IDs you located in the first step of this procedure.
 1. Click **Update**.
+
+##<a id="access"></a> Access the Cluster
+
+Perform the following steps to complete cluster configuration:
+
+1. From your local workstation, run `pks get-credentials CLUSTER-NAME`.
+This command creates a local `kubeconfig` that allows you to manage the cluster.
+For more information about the `pks get-credentials` command, see [Retrieving Cluster Credentials and Configuration](cluster-credentials.html).
+
+1. Run `kubectl cluster-info` to confirm you can access your cluster using the Kubernetes CLI.
+
+See [Managing <%= vars.product_short %>](managing.html) for information about checking cluster health and viewing cluster logs.
+


### PR DESCRIPTION
An operator following the steps on https://docs.pivotal.io/runtimes/pks/1-3/gcp-cluster-load-balancer.html would fail to access the cluster on step 4, since the firewall rules and the load balancer has not yet been configured.

Luis & @jhvhs 