### PR TITLE
Pks bbr all deployments

### DIFF
--- a/bbr-backup-cluster.html.md.erb
+++ b/bbr-backup-cluster.html.md.erb
@@ -29,6 +29,8 @@ current environment and the destination environment are compatible. For more inf
 [Compatibility of Restore](bbr-restore-cluster.html#compatibility) in
 _Restoring a Cluster_.
 
+When running BBR to back up your cluster deployments, ensure that you are using the correct BOSH credentials, as described below, which limit the scope of BBR to only your cluster deployments.
+
 Before you begin backing up your clusters, perform the following steps:
 
 * [Download the Root CA Certificate](#download-certificate)
@@ -44,7 +46,7 @@ steps below.
 
 1. Click **Download Root CA Cert**.
 
-## <a id='pre-backup-check'></a> Step 1: Verify Your Cluster Deployments
+## <a id='pre-backup-check'></a> Verify Your Cluster Deployments
 
 To verify that you can reach your BOSH Director and that the BOSH Director has deployments that
 can be backed up, follow the steps below.
@@ -54,23 +56,23 @@ can be backed up, follow the steps below.
 1. To perform the BBR pre-backup check, run the following command from your jumpbox:
 
     ```
-    BOSH_CLIENT_SECRET=BOSH-CLIENT-SECRET \
+    BOSH_CLIENT_SECRET=BOSH-TEAM-CLIENT-SECRET \
     bbr deployment \
     --all-deployments \
     --target BOSH-TARGET \
-    --username BOSH-CLIENT \
+    --username BOSH-TEAM-CLIENT \
     --ca-cert PATH-TO-BOSH-SERVER-CERT \
     pre-backup-check
     ```
     Replace the placeholder text as follows:
-    * `BOSH-CLIENT-SECRET`: In the BOSH Director tile, navigate to
-      **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_CLIENT_SECRET`.
+    * `BOSH-TEAM-CLIENT-SECRET`: In the PKS tile, navigate to
+      **Credentials > UAA Client Credentials**. Record the value for `uaa_client_secret`.
     * `BOSH-TARGET`: In the BOSH Director tile, navigate to
       **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_ENVIRONMENT`.
       You must be able to reach the target address from the workstation where you run `bbr`
       commands.
-    * `BOSH-CLIENT`: In the BOSH Director tile, navigate to
-      **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_CLIENT`.
+    * `BOSH-TEAM-CLIENT`: In the BOSH Director tile, navigate to
+      **Credentials > UAA Client Credentials**. Record the value for `uaa_client_name`.
     * `PATH-TO-BOSH-CA-CERT`: Use the path to the root CA certificate that you downloaded in the
       [Prerequisites](#prereqs) section.
 
@@ -80,7 +82,7 @@ can be backed up, follow the steps below.
     bbr deployment \
     --all-deployments \
     --target bosh.example.com \
-    --username admin \
+    --username pivotal-container-service-xxxxxx \
     --ca-cert bosh.ca.cert \
     pre-backup-check
     </pre>
@@ -92,31 +94,31 @@ can be backed up, follow the steps below.
       the deployments might not have the correct backup scripts, or the connection to
       the BOSH Director failed.
 
-## <a id='back-up'></a> Step 2: Back up Your Cluster Deployments
+## <a id='back-up-all'></a> Back up all your Cluster Deployments
 
 To back up your cluster deployments, follow the steps below.
 
 1. Run the following command from your jumpbox:
 
     ```
-    BOSH_CLIENT_SECRET=BOSH-CLIENT-SECRET \
+    BOSH_CLIENT_SECRET=BOSH-TEAM-CLIENT-SECRET \
     nohup bbr deployment \
     --all-deployments \
     --target BOSH-DIRECTOR-IP \
-    --username BOSH-CLIENT \
+    --username BOSH-TEAM-CLIENT \
     --ca-cert PATH-TO-BOSH-SERVER-CERT \
     backup
     ```
 
     Replace the placeholder text as follows:
-    * `BOSH-CLIENT-SECRET`: In the BOSH Director tile, navigate to
-      **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_CLIENT_SECRET`.
+    * `BOSH-TEAM-CLIENT-SECRET`: In the PKS tile, navigate to
+      **Credentials > UAA Client Credentials**. Record the value for `uaa_client_secret`.
     * `BOSH-TARGET`: In the BOSH Director tile, navigate to
       **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_ENVIRONMENT`.
       You must be able to reach the target address from the workstation where you run `bbr`
       commands.
-    * `BOSH-CLIENT`: In the BOSH Director tile, navigate to
-      **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_CLIENT`.
+    * `BOSH-TEAM-CLIENT`: In the BOSH Director tile, navigate to
+      **Credentials > UAA Client Credentials**. Record the value for `uaa_client_name`.
     * `PATH-TO-BOSH-CA-CERT`: Use the path to the root CA certificate that you downloaded in the
       [Prerequisites](#prereqs) section.
 
@@ -128,7 +130,7 @@ To back up your cluster deployments, follow the steps below.
     nohup bbr deployment \
     --all-deployments \
     --target bosh.example.com \
-    --username admin \
+    --username pivotal-container-service-xxxxxx \
     --ca-cert bosh.ca.cert \
     backup
     </pre>
@@ -178,24 +180,24 @@ may be left in a locked state.
 If you stop the backup process or the process fails, run the following command:
 
 ```
-BOSH_CLIENT_SECRET=BOSH-CLIENT-SECRET \
+BOSH_CLIENT_SECRET=BOSH-TEAM-CLIENT-SECRET \
 bbr deployment \
 --all-deployments \
 --target BOSH-TARGET \
---username BOSH-CLIENT \
+--username BOSH-TEAM-CLIENT \
 --ca-cert PATH-TO-BOSH-CA-CERT \
 backup-cleanup
 ```
 
 Replace the placeholder text as follows:
 
-* `BOSH-CLIENT-SECRET`: In the BOSH Director tile, navigate to
-  **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_CLIENT_SECRET`.
+* `BOSH-TEAM-CLIENT-SECRET`: In the PKS tile, navigate to
+  **Credentials > UAA Client Credentials**. Record the value for `uaa_client_secret`.
 * `BOSH-TARGET`: In the BOSH Director tile, navigate to
   **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_ENVIRONMENT`. You must
   be able to reach the target address from the workstation where you run `bbr` commands.
-* `BOSH-CLIENT`: In the BOSH Director tile, navigate to
-  **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_CLIENT`.
+* `BOSH-TEAM-CLIENT`: In the BOSH Director tile, navigate to
+  **Credentials > UAA Client Credentials**. Record the value for `uaa_client_name`.
 * `PATH-TO-BOSH-CA-CERT`: Use the path to the root CA certificate that you downloaded in the
   [Prerequisites](#prereqs) section.
 
@@ -206,7 +208,7 @@ $ BOSH_CLIENT_SECRET=p455w0rd \
 bbr deployment \
 --all-deployments \
 --target bosh.example.com \
---username admin \
+--username pivotal-container-service-xxxxxx \
 --ca-cert bosh.ca.crt \
 backup-cleanup
 </pre>

--- a/bbr-backup-cluster.html.md.erb
+++ b/bbr-backup-cluster.html.md.erb
@@ -15,6 +15,7 @@ To restore a cluster with BBR, see the instructions in
 
 BBR has the following limitations:
 
+* BBR can only back up a single-master cluster.
 * BBR does not back up the contents of disks that are attached to nodes.
 * BBR only backs up and restores the cluster etcd data.
 This includes the cluster-deployed workloads.
@@ -28,10 +29,9 @@ current environment and the destination environment are compatible. For more inf
 [Compatibility of Restore](bbr-restore-cluster.html#compatibility) in
 _Restoring a Cluster_.
 
-Before you begin backing up your cluster deployment, perform the following steps:
+Before you begin backing up your clusters, perform the following steps:
 
 * [Download the Root CA Certificate](#download-certificate)
-* [Record Your Cluster BOSH Deployment Name](#record-name)
 
 ### <a id='download-certificate'></a> Download the Root CA Certificate
 
@@ -44,47 +44,9 @@ steps below.
 
 1. Click **Download Root CA Cert**.
 
-### <a id='record-name'></a> Record Your Cluster BOSH Deployment Name
+## <a id='pre-backup-check'></a> Step 1: Verify Your Cluster Deployments
 
-Locate and record your cluster BOSH deployment name by following the steps below.
-
-1. <%= partial 'login-pks-api' %>
-
-1. To find the cluster ID associated with the cluster you want to back up, run the following
-command:
-
-    ```
-    pks cluster CLUSTER-NAME
-    ```
-    Where `CLUSTER-NAME` is the name of your cluster. From the output of this command, record the
-    value of **UUID**.
-
-1. From the Ops Manager Installation Dashboard, click the **BOSH Director** tile.
-
-1. Select the **Credentials** tab.
-
-1. Navigate to **Bosh Commandline Credentials** and click **Link to Credential**.
-
-1. Copy the credential value.
-
-1. SSH into your jumpbox. For more information about configuring the jumpbox, see [Installing BOSH Backup and Restore](bbr-install.html#jumpbox-setup).
-
-1. To retrieve your cluster BOSH deployment name, run the following command:
-
-    ```
-    BOSH-CLI-CREDENTIALS deployments | grep UUID
-    ```
-    Where:
-	 * `BOSH-CLI-CREDENTIALS` is the credential value that you copied in the previous step.
-	 * `UUID` is the cluster UUID that you recorded in
-    [Record Your Cluster BOSH Deployment Name](#record-name).
-    <br><br>
-    Your cluster BOSH deployment name begins with `service-instance` and includes a unique
-    identifier.
-
-## <a id='pre-backup-check'></a> Step 1: Verify Your Cluster Deployment
-
-To verify that you can reach your BOSH Director and that the BOSH Director has a deployment that
+To verify that you can reach your BOSH Director and that the BOSH Director has deployments that
 can be backed up, follow the steps below.
 
 1. SSH into your jumpbox. For more information about the jumpbox, see [Installing BOSH Backup and Restore](bbr-install.html#jumpbox-setup).
@@ -94,9 +56,9 @@ can be backed up, follow the steps below.
     ```
     BOSH_CLIENT_SECRET=BOSH-CLIENT-SECRET \
     bbr deployment \
+    --all-deployments \
     --target BOSH-TARGET \
     --username BOSH-CLIENT \
-    --deployment DEPLOYMENT-NAME \
     --ca-cert PATH-TO-BOSH-SERVER-CERT \
     pre-backup-check
     ```
@@ -109,8 +71,6 @@ can be backed up, follow the steps below.
       commands.
     * `BOSH-CLIENT`: In the BOSH Director tile, navigate to
       **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_CLIENT`.
-    * `DEPLOYMENT-NAME`: Use the cluster BOSH deployment name that you recorded in the
-      [Prerequisites](#prereqs) section.
     * `PATH-TO-BOSH-CA-CERT`: Use the path to the root CA certificate that you downloaded in the
       [Prerequisites](#prereqs) section.
 
@@ -118,9 +78,9 @@ can be backed up, follow the steps below.
     <pre class="terminal">
     $ BOSH_CLIENT_SECRET=p455w0rd \
     bbr deployment \
+    --all-deployments \
     --target bosh.example.com \
     --username admin \
-    --deployment cf-acceptance-0 \
     --ca-cert bosh.ca.cert \
     pre-backup-check
     </pre>
@@ -129,21 +89,21 @@ can be backed up, follow the steps below.
     * Run the command again, adding the `--debug` flag to enable debug logs. For more information,
       see [Exit Codes and Logging](bbr-logging.html).
     * Make the changes suggested in the output and run the pre-backup check again. For example,
-      the deployment you selected might not have the correct backup scripts, or the connection to
+      the deployments might not have the correct backup scripts, or the connection to
       the BOSH Director failed.
 
-## <a id='back-up'></a> Step 2: Back up Your Cluster Deployment
+## <a id='back-up'></a> Step 2: Back up Your Cluster Deployments
 
-To back up your cluster deployment, follow the steps below.
+To back up your cluster deployments, follow the steps below.
 
 1. Run the following command from your jumpbox:
 
     ```
     BOSH_CLIENT_SECRET=BOSH-CLIENT-SECRET \
     nohup bbr deployment \
+    --all-deployments \
     --target BOSH-DIRECTOR-IP \
     --username BOSH-CLIENT \
-    --deployment DEPLOYMENT-NAME \
     --ca-cert PATH-TO-BOSH-SERVER-CERT \
     backup
     ```
@@ -157,8 +117,6 @@ To back up your cluster deployment, follow the steps below.
       commands.
     * `BOSH-CLIENT`: In the BOSH Director tile, navigate to
       **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_CLIENT`.
-    * `DEPLOYMENT-NAME`: Use the cluster BOSH deployment name that you recorded in the
-      [Prerequisites](#prereqs) section.
     * `PATH-TO-BOSH-CA-CERT`: Use the path to the root CA certificate that you downloaded in the
       [Prerequisites](#prereqs) section.
 
@@ -168,9 +126,9 @@ To back up your cluster deployment, follow the steps below.
     <pre class="terminal">
     $ BOSH_CLIENT_SECRET=p455w0rd \
     nohup bbr deployment \
+    --all-deployments \
     --target bosh.example.com \
     --username admin \
-    --deployment cf-acceptance-0 \
     --ca-cert bosh.ca.cert \
     backup
     </pre>
@@ -191,9 +149,6 @@ If your backup fails, follow these steps below:
 1. Ensure that all the parameters in the command are set.
 
 1. Ensure that the BOSH Director credentials are valid.
-
-1. If you are backing up a deployment, ensure the deployment that you specify in the backup command
-exists.
 
 1. Ensure that the jumpbox can reach the BOSH Director.
 
@@ -225,9 +180,9 @@ If you stop the backup process or the process fails, run the following command:
 ```
 BOSH_CLIENT_SECRET=BOSH-CLIENT-SECRET \
 bbr deployment \
+--all-deployments \
 --target BOSH-TARGET \
 --username BOSH-CLIENT \
---deployment DEPLOYMENT-NAME \
 --ca-cert PATH-TO-BOSH-CA-CERT \
 backup-cleanup
 ```
@@ -241,8 +196,6 @@ Replace the placeholder text as follows:
   be able to reach the target address from the workstation where you run `bbr` commands.
 * `BOSH-CLIENT`: In the BOSH Director tile, navigate to
   **Credentials > Bosh Commandline Credentials**. Record the value for `BOSH_CLIENT`.
-* `DEPLOYMENT-NAME`: Use the cluster BOSH deployment name that you recorded in the
-  [Prerequisites](#prereqs) section.
 * `PATH-TO-BOSH-CA-CERT`: Use the path to the root CA certificate that you downloaded in the
   [Prerequisites](#prereqs) section.
 
@@ -251,9 +204,9 @@ For example:
 <pre class="terminal">
 $ BOSH_CLIENT_SECRET=p455w0rd \
 bbr deployment \
+--all-deployments \
 --target bosh.example.com \
 --username admin \
---deployment cf-acceptance-0 \
 --ca-cert bosh.ca.crt \
 backup-cleanup
 </pre>
@@ -276,13 +229,13 @@ message.
   </tr>
   <tr>
     <td>8</td>
-    <td>The post-backup unlock failed. Your deployment might be in a bad state and require
+    <td>The post-backup unlock failed. One of your deployments might be in a bad state and require
       attention.</td>
   </tr>
   <tr>
     <td>16</td>
     <td>The cleanup failed. This is a non-fatal error indicating that the utility has been unable
-      to clean up open BOSH SSH connections to the deployment VMs. Manual cleanup might be required
+      to clean up open BOSH SSH connections to a deployment's VMs. Manual cleanup might be required
       to clear any hanging BOSH users and connections.</td>
   </tr>
 </table>
@@ -294,7 +247,7 @@ For more information about interpreting the exit codes, see
 
 Keep your backup artifact safe in the following ways:
 
-* Move the backup artifact off the jumpbox to a secure storage space. BBR stores each backup in a
+* Move the backup artifacts off the jumpbox to a secure storage space. BBR stores each backup in a
 subdirectory named `DEPLOYMENT-TIMESTAMP` within the current working directory. The backup created
 by BBR consists of a folder that contains the backup artifacts and metadata files.
 

--- a/bbr-backup-cluster.html.md.erb
+++ b/bbr-backup-cluster.html.md.erb
@@ -260,3 +260,19 @@ minimize the risk of losing your backups in the event of a disaster.
 
 * Each time you redeploy a cluster, test your backup artifact by following the procedures in
 [Restore a Cluster](bbr-restore-cluster.html).
+
+## <a id='back-up-one'></a> Back up a Single Cluster Deployment
+
+To back up a specific cluster deployment you will have to replace the `--all-deployments` BBR flag with the `--deployment DEPLOYMENT-NAME` flag. The `DEPLOYMENT-NAME` is the name of the cluster deployment that you want to back up.
+
+For example:
+
+<pre class="terminal">
+$ BOSH_CLIENT_SECRET=p455w0rd \
+nohup bbr deployment \
+--deployment service-instance_xxxxxx \
+--target bosh.example.com \
+--username pivotal-container-service-xxxxxx \
+--ca-cert bosh.ca.cert \
+backup
+</pre>


### PR DESCRIPTION
Hey folks,

This PR updates the docs to instruct people to use the `--all-deployments` flag when backing up their cluster deployments on PKS.  This is the recommended way of doing this and should be present in `1.3` onwards.  So please port this to all versions `1.3` onwards!

Please remove this line in versions `1.4` onwards but keep for version `1.3`.
[* BBR can only back up a single-master cluster.](https://github.com/gmrodgers/docs-pks/blob/44d856856b69e6d23fad320d80970df5cc561616/bbr-backup-cluster.html.md.erb#L18)

We also wanted to change the subnav headings for backing up and restoring a cluster deployments, but we did not have access to the `docs-book-pks` repo.  If you could change the two headings as shown in the `git diff` below:

```diff
diff --git a/master_middleman/source/subnavs/pks_subnav.erb b/master_middleman/source/subnavs/pks_subnav.erb
index 6bcaf29..0620f3f 100644
--- a/master_middleman/source/subnavs/pks_subnav.erb
+++ b/master_middleman/source/subnavs/pks_subnav.erb
@@ -317,10 +317,10 @@
             <a href="/runtimes/pks/1-3/bbr-restore.html">Restoring the PKS Control Plane</a>
           </li>
           <li>
-            <a href="/runtimes/pks/1-3/bbr-backup-cluster.html">Backing up the Single Master Cluster</a>
+            <a href="/runtimes/pks/1-3/bbr-backup-cluster.html">Backing up Clusters</a>
           </li>
           <li>
-            <a href="/runtimes/pks/1-3/bbr-restore-cluster.html">Restoring the Single Master Cluster</a>
+            <a href="/runtimes/pks/1-3/bbr-restore-cluster.html">Restoring a Cluster</a>
           </li>
           <li>
             <a href="/runtimes/pks/1-3/bbr-logging.html">BBR Logging</a>
```

If you've anymore questions, drop us a message!

Thanks,
Glen && @alamages