### PR TITLE
Removing version info from doc

### DIFF
--- a/upgrade-pks-nsxt.html.md.erb
+++ b/upgrade-pks-nsxt.html.md.erb
@@ -18,103 +18,11 @@ This section describes the activities you must perform before upgrading PKS.
 
 ### <a id="compatiblity-chart"></a>Consult Compatibility Charts
 
-For information about PKS with NSX-T and Ops Manager compatibility, refer to the compatibility chart below:
-
-<table>
-  <tr>
-    <th>PKS Version</th>
-    <th>Compatible NSX-T Versions</th>
-    <th>Compatible Ops Manager Versions</th>
-  </tr>
-  <tr>
-    <td>v1.3.x</td>
-    <td>v2.2, v2.3</td>
-    <td>v2.3.1+, v2.4.x</td>
-  </tr>
-  <tr>
-    <td>v1.2.x</td>
-    <td>v2.2, v2.3</td>
-    <td>v2.2.3+, v2.3.1+</td>
-  </tr>
-  <tr>
-    <td>v1.1.6</td>
-    <td>v2.1, v2.2</td>
-    <td>v2.1.x, 2.2.x</td>
-  <tr>
-    <td>v1.1.5</td>
-    <td>v2.1, v2.2</td>
-    <td>v2.1.x, v2.2.x</td>
-  </tr>
-  <tr>
-    <td>v1.1.4</td>
-    <td>v2.1</td>
-    <td>v2.1.x, 2.2.x</td>
-  </tr>
-  <tr>
-    <td>v1.1.3</td>
-    <td>v2.1</td>
-    <td>v2.1.0 - 2.1.6</td>
-  </tr>
-  <tr>
-    <td>v1.1.2</td>
-    <td>v2.1</td>
-    <td>v2.1.x, 2.2.x</td>
-  </tr>
-  <tr>
-    <td>v1.1.1</td>
-    <td>v2.1 - Advanced Edition</td>
-    <td>v2.1.0 - 2.1.6</td>
-  </tr>
-</table>
-
-For more information on NSX-T product compatibility, see the [VMware Product Interoperability Matrix](https://www.vmware.com/resources/compatibility/sim/interop_matrix.php) for PKS in the VMware documentation.
+For information about PKS with NSX-T and Ops Manager compatibility, refer to the release notes.
 
 ### <a id="upgrade-path"></a> Determine Your Upgrade Path
 
-Use the following table to determine your upgrade path to PKS v1.3 with NSX-T. PKS v1.3 supports NSX-T v2.3, which is the recommended NSX-T version.
-
-<table>
-<tr>
-  <th>If your current version of PKS is...</th>
-  <th>Then use the following upgrade path:</th>
-</tr>
-<tr>
-  <td>v1.1.4 or earlier</td>
-  <td>
-    <ol>
-      <li>Upgrade to PKS v1.1.5 or later.</li>
-      <li>Upgrade to NSX-T v2.2.</li>
-      <li>Upgrade to Ops Manager v2.3.1 or later.</li>
-      <li>Upgrade to PKS v1.2.5.</li>
-      <li>Upgrade to NSX-T v2.3.</li>
-      <li>(Optional) Upgrade to Ops Manager v2.4.x.</li>
-      <li>Upgrade to PKS v1.3.x.</li>
-    </ol>
-  </td>
-</tr>
-<tr>
-  <td>v1.1.5 to v1.2.4</td>
-  <td>
-    <ol>
-      <li>Upgrade to NSX-T v2.2.</li>
-      <li>Upgrade to Ops Manager v2.3.1 or later.</li>
-      <li>Upgrade to PKS v1.2.5.</li>
-      <li>Upgrade to NSX-T v2.3.</li>
-      <li>(Optional) Upgrade to Ops Manager v2.4.x.</li>
-      <li>Upgrade to PKS v1.3.x.</li>
-    </ol>
-  </td>
-</tr>
-<tr>
-  <td>v1.2.5 or later</td>
-  <td>
-    <ol>
-      <li>Upgrade to Ops Manager v2.3.1 or later, or Ops Manager v2.4.x.</li>
-      <li>Upgrade to PKS v1.3.x.</li>
-    </ol>
-  </td>
-</tr>
-</table>
+For information about the supported upgrade path, refer to the release notes.
 
 ### <a id="prepare"></a>Prepare to Upgrade
 


### PR DESCRIPTION
Embedding this info in the docs is causing a lot of headaches. We need to refer to a single source of truth. Going forward, Anish will put upgrade paths info on PivNet, which will be copied to the RNs. Thanks.