### PR TITLE
Add location of ca cert to documentation

### DIFF
--- a/manage-users.html.md.erb
+++ b/manage-users.html.md.erb
@@ -111,7 +111,7 @@ To retrieve the PKS UAA management admin client secret, do the following:
     Where:
     * `PKS-API` is the URL to your PKS API server. You configured this URL in the PKS API section of _Installing PKS_ for your IaaS. For example, see [Installing PKS on vSphere](installing-pks-vsphere.html#pks-api).
     * `ROOT-CA-FILENAME` is the certificate file you downloaded in [Configuring PKS API Access](configure-api.html#access).
-
+      * If you are on the ops man instance, it should be located at `/var/tempest/workspaces/default/root_ca_certificate`.
     For example:
     <pre class="terminal">
     $ uaac target api.pks.example.com:8443 --ca-cert my-cert.cert


### PR DESCRIPTION
This doc currently leads users to another page which has not any more information about how to locate the ca cert.
If you look at the "advanced troubleshooting with the bosh cli" it starts much the same, with sshing onto the opsman, but it actually
tells you were to locate the certificate. If I followed these directions, I would have to a) follow link, b) follow second link, c) Realize I cannot curl endpoint for certificate until I have a bearer token for opsman. d) have to look up more documentation on how to get a bearer token, and re look up various credentials.

If you are already on the opsman there is no reason for this.

Possibly the page that it is linked to should include this information as well.