### PR TITLE
Fixing ref paths so the topics render correctly in VMW MD2HTML tool

### DIFF
--- a/aws-cluster-load-balancer.html.md.erb
+++ b/aws-cluster-load-balancer.html.md.erb
@@ -7,7 +7,7 @@ This topic describes how to configure a Amazon Web Services (AWS) load balancer 
 
 A load balancer is a third-party device that distributes network and application traffic across resources. 
 Using a load balancer can also prevent individual network components from being overloaded by high traffic. 
-For more information about the different types of load balancers used in a <%= vars.product_short %> deployment see [Load Balancers in PKS](../about-lb.html).  
+For more information about the different types of load balancers used in a <%= vars.product_short %> deployment see [Load Balancers in PKS](about-lb.html).  
 
 You can use an AWS <%= vars.product_short %> cluster load balancer to secure and facilitate access to a <%= vars.product_short %> cluster from outside the network. 
 You can also [reconfigure](#reconfigure) your AWS <%= vars.product_short %> cluster load balancers.  

--- a/create-cluster.html.md.erb
+++ b/create-cluster.html.md.erb
@@ -142,4 +142,4 @@ For example, if you use GCP, use the master VM IDs from the previous step in [Re
 ## <a id='next-steps'></a> Next Steps
 
 If your <%= vars.product_short %> deployment is on AWS, you must tag your subnets with your new cluster's unique identifier before adding the subnets to the 
-<%= vars.product_short %> workload load balancer. After you complete the [Create a Kubernetes Cluster](#create) procedure, follow the instructions in [AWS Prerequisites](../deploy-workloads.html#aws).
+<%= vars.product_short %> workload load balancer. After you complete the [Create a Kubernetes Cluster](#create) procedure, follow the instructions in [AWS Prerequisites](deploy-workloads.html#aws).

--- a/deploy-workloads.html.md.erb
+++ b/deploy-workloads.html.md.erb
@@ -9,7 +9,7 @@ This topic describes how to deploy and access basic workloads in Pivotal Contain
 
 A load balancer is a third-party device that distributes network and application traffic across resources. 
 Using a load balancer can also prevent individual network components from being overloaded by high traffic. 
-For more information about the different types of load balancers used in a <%= vars.product_short %> deployment see [Load Balancers in PKS](../about-lb.html). 
+For more information about the different types of load balancers used in a <%= vars.product_short %> deployment see [Load Balancers in PKS](about-lb.html). 
 
 If you use Google Cloud Platform (GCP), Amazon Web Services (AWS), or vSphere with NSX-T integration, your cloud provider can configure an external load balancer for your workload.
 See [Access Workloads Using an External Load Balancer](#external-lb).


### PR DESCRIPTION
The VMW conversion tool MD2HTML cannot process these reference paths. We have to fix them manually until this is merged. Also applies to the 1.4/master branch. Thanks. 

Invalid path in file: aws-cluster-load-balancer.html in text: ../about-lb.html
Invalid path in file: create-cluster.html in text: ../deploy-workloads.html
Invalid path in file: deploy-workloads.html in text: ../about-lb.html
