### PR TITLE
Fixing Quota commands to allow copy&paste

### DIFF
--- a/_create-auth-token-var.html.md.erb
+++ b/_create-auth-token-var.html.md.erb
@@ -1,8 +1,8 @@
 To export your access token into an environment variable, run the following command:
 
 <pre>
-pks login -a PKS-API -u USER-ID -p 'PASSWORD' \
--k export YOUR-ACCESS-TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
+pks login -a PKS-API -u USER-ID -p 'PASSWORD' -k; \
+export YOUR_ACCESS_TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
 </pre>
 
 Where:
@@ -10,10 +10,10 @@ Where:
 * `PKS-API` is the FQDN of your PKS API endpoint. For example, `api.pks.example.com`.
 * `USER-ID` is your <%= vars.product_short %> user ID.
 * `PASSWORD` is your <%= vars.product_short %> password.
-* `YOUR-ACCESS-TOKEN` is the name of your access token environment variable.  
+* `YOUR_ACCESS_TOKEN` is the name of your access token environment variable.  
 
 For example:
 <pre class="terminal">
-$ pks login -a pks.my.lab -u alana -p 'psswrdabc123...!' \
--k export my-token=$(bosh int ~/.pks/creds.yml --path /access_token)
+$ pks login -a pks.my.lab -u alana -p 'psswrdabc123...!' -k; \
+export my_token=$(bosh int ~/.pks/creds.yml --path /access_token)
 </pre>  

--- a/resource-usage.html.md.erb
+++ b/resource-usage.html.md.erb
@@ -36,48 +36,68 @@ This section describes how to add, modify and delete user quotas.
 To enforce a quota on a specific user, run the following command:
 
 ```
-curl -k -H "Authorization: Bearer $YOUR-ACCESS-TOKEN" \
+curl -k -X POST \
+-H "Authorization: Bearer $YOUR_ACCESS_TOKEN" \
 -H "Content-Type: application/json" \
 -d \
-'{ \
-    "owner": "USER-ID", \
-    "limit": { \
-      "cpu": MAX-CPU, \
-      "memory": MAX-MEM \
-      } \
+'{ 
+    "owner": "USER-ID",
+    "limit": { 
+      "cpu": MAX-CPU, 
+      "memory": MAX-MEM 
+      } 
     }' \
 https://PKS-API:9021/v1beta1/quotas
 ```
 
 Where:
 
-* `YOUR-ACCESS-TOKEN` is your access token environment variable.
+* `YOUR_ACCESS_TOKEN` is your access token environment variable.
 * `USER-ID` is the user account ID to enforce the quota restriction on.
 * `MAX-CPU` is the maximum total amount of CPU resources the user can allocate to containers and pods.
 * `MAX-MEM` is the maximum total amount of memory, in gigabytes, the user can allocate to containers and pods.
 * `PKS-API` is the FQDN of your PKS API endpoint. 
+
+For example:
+<pre class="terminal">
+$ user=exampleuser
+$ pks login -a pks.my.lab -u $user -p 'psswrdabc123...!' -k; export TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
+$ curl -k -X POST \
+-H "Authorization: Bearer $TOKEN" \
+-H "Content-Type: application/json" \
+-d \
+'{
+    "owner": "cody",
+    "limit": {
+        "cpu": 4,
+        "memory": 5
+    }
+  }' \
+https&#58;//example.com&#58;9021/v1beta1/quotas
+</pre>
 
 ### <a id='quota-modify'></a> Modify an Existing Quota
 
 To modify a specific user's existing quota, run the following command:
 
 ```
-curl -k -X PATCH -H "Authorization: Bearer $YOUR-ACCESS-TOKEN" \
+curl -k -X PATCH  \ 
+-H "Authorization: Bearer $YOUR_ACCESS_TOKEN" \
 -H "Content-Type: application/json" \
 -d \
-'{ \
-    "owner": "USER-ID", \
-    "limit": { \
-      "cpu": MAX-CPU, \
-      "memory": MAX-MEM \
-      } \
+'{ 
+    "owner": "USER-ID", 
+    "limit": { 
+      "cpu": MAX-CPU, 
+      "memory": MAX-MEM 
+      } 
     }' \
 https://PKS-API:9021/v1beta1/quotas/USER-ID
 ```
 
 Where:
 
-* `YOUR-ACCESS-TOKEN` is your access token environment variable.
+* `YOUR_ACCESS_TOKEN` is your access token environment variable.
 * `USER-ID` is the user account ID to enforce the quota restriction on.
 * `MAX-CPU` is the maximum total amount of CPU resources the user can allocate to containers and pods.
 * `MAX-MEM` is the maximum total amount of memory, in gigabytes, the user can allocate to containers and pods.
@@ -86,16 +106,19 @@ Where:
 For example:
 <pre class="terminal">
 $ user=exampleuser
-$ pks login -a pks.my.lab -u $user -p 'psswrdabc123...!' -k export TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
-$ curl -v -k -X PATCH -H "Authorization: Bearer $TOKEN" \
--H "Content-Type: application/json" -d \
-'{ \
-    "owner": "cody",  \
-    "limit": {  \
-        "cpu": 4,  \
-        "memory": 5 \
-    }  \
-}' https&#58;//example.com&#58;9021/v1beta1/quotas/$user
+$ pks login -a pks.my.lab -u $user -p 'psswrdabc123...!' -k; export TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
+$ curl -k -X PATCH \
+-H "Authorization: Bearer $TOKEN" \
+-H "Content-Type: application/json" \
+-d \
+'{ 
+    "owner": "cody", 
+    "limit": {  
+        "cpu": 4, 
+        "memory": 5 
+    }
+  }' \
+https&#58;//example.com&#58;9021/v1beta1/quotas/$user
 </pre>
 
 ### <a id='quota-delete'></a> Delete a Quota
@@ -103,20 +126,20 @@ $ curl -v -k -X PATCH -H "Authorization: Bearer $TOKEN" \
 To delete a specific user's existing quota, run the following command:
 
 ```
-curl -k -X DELETE -H "Authorization: Bearer $YOUR-ACCESS-TOKEN" \
+curl -k -X DELETE -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" \
 https://PKS-API:9021/v1beta1/quotas/USER-ID
 ```
 
 Where:
 
-* `YOUR-ACCESS-TOKEN` is your access token environment variable.
+* `YOUR_ACCESS_TOKEN` is your access token environment variable.
 * `PKS-API` is the FQDN of your PKS API endpoint.
 * `USER-ID` is the user account ID to enforce the quota restriction on.
 
 For example:
 <pre class="terminal">
 $ user=exampleuser
-$ pks login -a pks.my.lab -u $user -p 'psswrdabc123...!' -k export TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
+$ pks login -a pks.my.lab -u $user -p 'psswrdabc123...!' -k; export TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
 $ curl -k -X DELETE -H "Authorization: Bearer $TOKEN" https&#58;//example.com&#58;9021/v1beta1/quotas/$user
 $ curl -k -X DELETE -H "Authorization: Bearer $TOKEN" https&#58;//example.com&#58;9021/v1beta1/quotas/$user
 {
@@ -131,21 +154,21 @@ The PKS API `quotas` command reports resource utilization quotas as JSON.
 To to list the resource quota restrictions currently applied to a single user, run the following command:
 
 ```
-curl -k -H "Authorization: Bearer $YOUR-ACCESS-TOKEN" \
+curl -k -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" \
 https://PKS-API:9021/v1beta1/quotas/USER-ID
 ```
 
 Where:
 
-* `YOUR-ACCESS-TOKEN` is your access token environment variable.
+* `YOUR_ACCESS_TOKEN` is your access token environment variable.
 * `PKS-API` is the FQDN of your PKS API endpoint. 
 * `USER-ID` is the user account ID to report on.  
 
 For example:
 <pre class="terminal">
 $ user=exampleuser
-$ pks login -a pks.my.lab -u $user -p 'psswrdabc123...!' -k export TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
-$ curl -v -k -H "Authorization: Bearer $TOKEN" \
+$ pks login -a pks.my.lab -u $user -p 'psswrdabc123...!' -k; export TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
+$ curl -k -H "Authorization: Bearer $TOKEN" \
 https&#58;//example.com&#58;9021/v1beta1/quotas/$user 
 {
   "owner":"cody",
@@ -160,20 +183,20 @@ https&#58;//example.com&#58;9021/v1beta1/quotas/$user
 To list all current resource quota restrictions, run the following command:
 
 ```
-curl -k -H "Authorization: Bearer $YOUR-ACCESS-TOKEN" \
+curl -k -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" \
 https://PKS-API:9021/v1beta1/quotas
 ```
 
 Where:
 
-* `YOUR-ACCESS-TOKEN` is your access token environment variable.
+* `YOUR_ACCESS_TOKEN` is your access token environment variable.
 * `PKS-API` is the FQDN of your PKS API endpoint.
 
 For example:
 <pre class="terminal">
 $ user=exampleuser
-$ pks login -a pks.my.lab -u $user -p 'psswrdabc123...!' -k export TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
-$ curl -v -k -H "Authorization: Bearer $TOKEN" \
+$ pks login -a pks.my.lab -u $user -p 'psswrdabc123...!' -k; export TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
+$ curl -k -H "Authorization: Bearer $TOKEN" \
 https&#58;//example.com&#58;9021/v1beta1/quotas
 [
   {
@@ -193,23 +216,47 @@ The PKS API `usages` command reports resource utilization as JSON.
 To list the current resource utilization for a single user, run the following command:
 
 ```
-curl -k -H "Authorization: Bearer $YOUR-ACCESS-TOKEN" https://PKS-API:9021/v1beta1/usages/USER-ID
+curl -k -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" https://PKS-API:9021/v1beta1/usages/USER-ID
 ```
 
 Where:
 
-* `YOUR-ACCESS-TOKEN` is your access token environment variable.
+* `YOUR_ACCESS_TOKEN` is your access token environment variable.
 * `PKS-API` is the FQDN of your PKS API endpoint.
 * `USER-ID` is the user account ID whose resource utilization you want to view.  
 
 To list the current resource utilization for all users, run the following command:
 
 ```
-curl -k -H "Authorization: Bearer $YOUR-ACCESS-TOKEN" \
+curl -k -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" \
 https://PKS-API:9021/v1beta1/usages
 ```
 
 Where:
 
-* `YOUR-ACCESS-TOKEN` is your authentication token environment variable.
+* `YOUR_ACCESS_TOKEN` is your authentication token environment variable.
 * `PKS-API` is the FQDN of your PKS API endpoint.
+
+For example:
+<pre class="terminal">
+$ user=exampleuser
+$ pks login -a pks.my.lab -u $user -p 'psswrdabc123...!' -k; export TOKEN=$(bosh int ~/.pks/creds.yml --path /access_token)
+$ curl -k -H "Authorization: Bearer $TOKEN" \
+https&#58;//example.com&#58;9021/v1beta1/usages
+[
+  {
+    "owner": "cody",
+    "totals": {
+      "cpu": 20,
+      "memory": 52
+    },
+    "clusters": [
+      {
+        "name": "vsp1",
+        "cpu": 12,
+        "memory": 36
+      }
+    ]
+  }
+]
+</pre>


### PR DESCRIPTION
Most current commands fail due to formatting problems when you try to run them as is.
I amended those and included a couple more examples