### PR TITLE
Add directions for ssh to cluster master node

### DIFF
--- a/_ssh-cluster-master-node.html.md.erb
+++ b/_ssh-cluster-master-node.html.md.erb
@@ -1,0 +1,42 @@
+1. Gather credential and IP address information for your BOSH Director, SSH into
+the Ops Manager VM, and use BOSH CLI to log in to the BOSH Director from the Ops
+Manager VM. For more information, see [Advanced Troubleshooting with the BOSH
+CLI](https://docs.pivotal.io/pivotalcf/customizing/trouble-advanced.html).
+
+1. To identify your PKS deployment's name, run the following command:
+  <pre>bosh -e ENVIRONMENT deployments</pre>
+
+    Where `ENVIRONMENT` is the BOSH environment alias you set in the [Set a BOSH Environment Alias](manage-deployments-bosh.html#alias) section of _Managing PKS Deployments with BOSH_.
+  <br>
+  <br>
+    For example:
+      <pre class="terminal">$ bosh -e pks deployments</pre>
+      Your PKS deployment name begins with `pivotal-container-service` and includes
+  a BOSH-generated hash.
+
+1. To identify your PKS VM's name, run the following command:
+  <pre>bosh -e ENVIRONMENT -d DEPLOYMENT vms</pre>
+
+    Where:
+     * `ENVIRONMENT` is the BOSH environment alias.
+     * `DEPLOYMENT` is your PKS deployment name.
+
+    For example:
+    <pre class="terminal">$ bosh -e pks -d service-instance_ae681cd1-7ff4-4661-b12c-49a5b543f16f vms</pre>
+
+    Your PKS VM name begins with `pivotal-container-service` and includes a
+  BOSH-generated hash.
+    <p class="note"><strong>Note:</strong> The PKS VM hash value is different from the hash in your PKS
+  deployment name.
+</p>
+
+1. To SSH into the master node of the cluster, run the following command:
+  <pre>bosh -e ENVIRONMENT -d DEPLOYMENT ssh master/MASTER_NUMBER</pre>
+
+    Where:
+    * `ENVIRONMENT` is the BOSH environment alias.
+    * `DEPLOYMENT` is your PKS deployment name.
+    * `MASTER_NUMBER` is your master number.
+
+    For example:
+    <pre class="terminal">$ bosh -e pks -d service-instance_ae681cd1-7ff4-4661-b12c-49a5b543f16f ssh master/0</pre>

--- a/diagnostic-tools.html.md.erb
+++ b/diagnostic-tools.html.md.erb
@@ -23,6 +23,11 @@ To SSH into the PKS VM using BOSH, follow the steps below:
 
 <%= partial 'bosh-ssh' %>
 
+## <a id='pks-api'></a>SSH into the Kubernetes Cluster Master node
+
+To SSH into the master node for a PKS Kubernetes cluster using BOSH, follow the steps below:
+
+<%= partial 'ssh-cluster-master-node' %>
 
 
 ##<a id='bosh-pks-map'></a>View Log Files


### PR DESCRIPTION
After we could not find directions on how to SSH to the pks cluster nodes, we thought we'd contribute this PR. This is handy for debugging configuration of PKS issues, e.g. wanting to discover the kube-apiserver config.

Co-authored-by: Todd Sedano <tsedano@pivotal.io>
Co-authored-by: Zimeng Yang <zimengy@vmware.com>