### PR TITLE
Fixing the vsphere versions in the release notes

### DIFF
--- a/_vsphere_versions.html.md.erb
+++ b/_vsphere_versions.html.md.erb
@@ -1,3 +1,23 @@
-
-For Enterprise PKS installations on vSphere or on vSphere with NSX-T Data Center, refer to the <a href="https://www.vmware.com/resources/compatibility/sim/interop_matrix.php#interop&356=&175=&1=">VMware Product Interoperability Matrices</a>.</p>
-
+<table class="nice">
+  <tr>
+    <th>Versions</th>
+    <th>Editions</th>
+  </tr>
+  <tr>
+    <td>
+      <ul>
+        <li>VMware vSphere 6.7 U2</li>
+        <li>VMware vSphere 6.7 U1</li>
+        <li>VMware vSphere 6.7.0</li>
+        <li>VMware vSphere 6.5 U2</li>
+        <li>VMware vSphere 6.5 U1</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>vSphere Enterprise Plus</li>
+        <li>vSphere with Operations Management Enterprise Plus</li>
+      </ul>
+    </td>
+  </tr>
+</table>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -73,8 +73,7 @@ or v2.4.3.</p>
 
 ### <a id='vsphere-reqs'></a> vSphere Version Requirements
 
-For <%= vars.product_short %> on vSphere or vSphere with NSX&#8209;T installatios, Ops Manager and <%= vars.product_short %> support the following vSphere component versions:
-<%= partial 'vsphere_versions' %>
+For <%= vars.product_short %> installations on vSphere or on vSphere with NSX-T Data Center, refer to the <a href="https://www.vmware.com/resources/compatibility/sim/interop_matrix.php#interop&356=&175=&1=">VMware Product Interoperability Matrices</a>.</p>
 
 ### <a id="v1.4.0-iaas"></a>Feature Support by IaaS
 


### PR DESCRIPTION
just point to the vmware interop matrix, restoring the partial in case someday we need it, but not referencing it anymore