### PR TITLE
Human readable cluster names

### DIFF
--- a/monitor-sinks.html.md.erb
+++ b/monitor-sinks.html.md.erb
@@ -28,7 +28,7 @@ robust set of filtering and monitoring options.
 Sink data has the following characteristics. All entries:
 
 * Are timestamped.
-* Contain the host ID of the BOSH-defined VM.
+* Contain the human readable cluster name.
 * Are annotated with a set of structured data, which includes the namespace, the object name or pod ID, and the container name.
 
 The logs you send using either the `Sink` or `ClusterSink` resource use the Syslog Protocol. For the `ClusterSink` resource, you can also use a webhook to send logs.
@@ -100,7 +100,7 @@ Pod logs entries are distinguished by the string `pod.log` in the `APP-NAME` fie
 The following is a sample pod log entry:
 
 <pre>
-36 <14>1 2018-11-26T18:51:41.647825+00:00 vm-3ebfe45d-492d-4bfd-59c4-c45d91688c65 
+36 <14>1 2018-11-26T18:51:41.647825+00:00 cluster-name
 pod.log/rocky-raccoon/logspewer-6b58b6689d-dhddj - - [kubernetes@47450 
 app="logspewer" pod-template-hash="2614622458" namespace_name="rocky-raccoon" 
 object_name="logspewer-6b58b6689d-dhddj" container_name="logspewer"] 
@@ -109,7 +109,7 @@ object_name="logspewer-6b58b6689d-dhddj" container_name="logspewer"]
 
 Where:
 
-  * `vm-3ebfe45d-492d-4bfd-59c4-c45d91688c65` is the host ID of the BOSH VM.
+  * `cluster-name` is the human readable cluster name used when creating the cluster
   * `pod.log` is the `APP-NAME`.
   * `rocky-raccoon` is the `NAMESPACE`.
   * `logspewer-6b58b6689d-dhddj` is the `POD-ID`.
@@ -121,7 +121,7 @@ Kubernetes API Event entries are distinguished by the string `k8s.event` in the 
 The following is an example Kubernetes API event log entry:
 
 <pre>
-Nov 14 16:01:49 vm-b409c60e-2517-47ac-7c5b-2cd302287c3a 
+Nov 14 16:01:49 cluster-name
 k8s.event/rocky-raccoon/logspewer-6b58b6689d-j9n: 
 Successfully assigned rocky-raccoon/logspewer-6b58b6689d-j9nq7 
 to vm-38dfd896-bb21-43e4-67b0-9d2f339adaf1
@@ -129,7 +129,7 @@ to vm-38dfd896-bb21-43e4-67b0-9d2f339adaf1
 
 Where:
 
-  * `vm-b409c60e-2517-47ac-7c5b-2cd302287c3a` the host ID of the BOSH VM.
+  * `cluster-name` is the human readable cluster name used when creating the cluster
   * `k8s.event` is the `APP-NAME`.
   * `rocky-raccoon` is the `NAMESPACE`.
   * `logspewer-6b58b6689d-j9n` is the `POD-ID`.
@@ -175,7 +175,7 @@ To monitor for these events, look for log entries that contain the <strong>Ident
    <tr>
       <th>Example Sink Log Entry</th>
       <td>
-      <code>Jan 25 09:26:44 vm-bfdfedef-4a6a-4c36-49fc-8b290ad42623 k8s.event/monitoring/cost-analyzer-prometheus-se: Back-off restarting failed container</code>
+      <code>Jan 25 09:26:44 cluster-name k8s.event/monitoring/cost-analyzer-prometheus-se: Back-off restarting failed container</code>
       </td>
    </tr>
 </table>
@@ -196,12 +196,12 @@ To monitor for these events, look for log entries that contain the <strong>Ident
       <th>Example Sink Log Entries</th>
       <td>
       <code>
-        Jan 25 09:14:55 35.239.18.250 k8s.event/rocky-raccoon/logspewer-6b58b6689d/: Created pod: logspewer-6b58b6689d-sr96t <br/>
-        Jan 25 09:14:55 35.239.18.250 k8s.event/rocky-raccoon/logspewer-6b58b6689d-sr9: Successfully assigned rocky-raccoon/ logspewer-6b58b6689d-sr96t to vm-efe48928-be8e-4db5-772c-426ee7aa52f2 <br/>
-        Jan 25 09:14:55 vm-efe48928-be8e-4db5-772c-426ee7aa52f2 k8s.event/rocky-raccoon/logspewer-6b58b6689d-mkd: Killing container with id docker://logspewer:Need to kill Pod <br/>
-        Jan 25 09:14:56 vm-efe48928-be8e-4db5-772c-426ee7aa52f2 k8s.event/rocky-raccoon/logspewer-6b58b6689d-sr9: Container image "oratos/logspewer:v0.1" already present on machine <br/>
-        Jan 25 09:14:56 vm-efe48928-be8e-4db5-772c-426ee7aa52f2 k8s.event/rocky-raccoon/logspewer-6b58b6689d-sr9: Created container <br/>
-        Jan 25 09:14:56 vm-efe48928-be8e-4db5-772c-426ee7aa52f2 k8s.event/rocky-raccoon/logspewer-6b58b6689d-sr9: Started container <br/>
+        Jan 25 09:14:55 cluster-name 35.239.18.250 k8s.event/rocky-raccoon/logspewer-6b58b6689d/: Created pod: logspewer-6b58b6689d-sr96t <br/>
+        Jan 25 09:14:55 cluster-name 35.239.18.250 k8s.event/rocky-raccoon/logspewer-6b58b6689d-sr9: Successfully assigned rocky-raccoon/ logspewer-6b58b6689d-sr96t to vm-efe48928-be8e-4db5-772c-426ee7aa52f2 <br/>
+        Jan 25 09:14:55 cluster-name k8s.event/rocky-raccoon/logspewer-6b58b6689d-mkd: Killing container with id docker://logspewer:Need to kill Pod <br/>
+        Jan 25 09:14:56 cluster-name  k8s.event/rocky-raccoon/logspewer-6b58b6689d-sr9: Container image "oratos/logspewer:v0.1" already present on machine <br/>
+        Jan 25 09:14:56 cluster-name  k8s.event/rocky-raccoon/logspewer-6b58b6689d-sr9: Created container <br/>
+        Jan 25 09:14:56 cluster-name  k8s.event/rocky-raccoon/logspewer-6b58b6689d-sr9: Started container <br/>
       </code>
       </td>
    </tr>


### PR DESCRIPTION
In PKS 1.4 we improved the log format to use the human readable cluster name rather than the vm id. This reflects that change.