### PR TITLE
Update release notes to clarify NSX-T recommendation

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -43,7 +43,7 @@ This topic contains release notes for <%= vars.product_full %> v1.4.x.
     </tr>
     <tr>
         <td>NSX-T versions</td>
-        <td>v2.3.1, v2.4.0.1, (recommended) v2.4.1</td>
+        <td>v2.3.1, v2.4.0.1, v2.4.1 (recommended) </td>
     </tr>
     <tr>
         <td>NCP version</td>


### PR DESCRIPTION
Having `(recommended)` prior to the recommended version seem to be confusing to users. 

I believe it can be expressed better if the comment is placed after the version.