### PR TITLE
Fix jumpbox key

### DIFF
--- a/bbr-backup.html.md.erb
+++ b/bbr-backup.html.md.erb
@@ -81,7 +81,7 @@ Moving backup artifacts can be significantly slower, increasing backup and resto
     * `PORT` is port to use to reach the jumpbox.
     * `JUMPBOX-USER` is the ssh username for connecting to the jumpbox.
     * `JUMPBOX-ADDRESS` is the IP address, or hostname, of the jumpbox.
-    * `JUMPBOX-KEYFILE` is the private key file you saved in [Save the BBR SSH Credentials to File](#bbr-ssh-creds-save) above.
+    * `JUMPBOX-KEYFILE` is the private key file of the jumpbox.
 
     For example:
     <pre class="terminal">


### PR DESCRIPTION
It was referencing the director SSH key, rather than the jumpbox ssh key.

Thanks!
Jake & @alamages 