### PR TITLE
Update gcp load balancer steps

### DIFF
--- a/gcp-cluster-load-balancer.html.md.erb
+++ b/gcp-cluster-load-balancer.html.md.erb
@@ -101,12 +101,20 @@ as the external hostname when you run the `pks create-cluster` command.
 
 To configure the back end of the load balancer, do the following:
 
-1. Navigate to the [Google Cloud Platform console](https://console.cloud.google.com/).
-1. In the sidebar menu, select **Network Services** > **Load balancing**.
-1. Select the load balancer you created for the cluster and select **Configure**.
-1. Click **Backend configuration** and configure the following settings:
-  1. Select all master VMs for your cluster from the dropdown. To locate the IP addresses and VM IDs of the master VMs, see [Identify Kubernetes Cluster Master VMs](create-cluster.html#master-id) in _Creating Clusters_.
-    <p class="note breaking"><strong>Breaking Change</strong>: If master VMs are recreated for any reason, such as a stemcell upgrade, you must reconfigure the load balancer to target the new master VMs. For more information, see the <a href="#reconfigure">Reconfigure Load Balancer</a> section below.
+1. Determine the IP and VM Name of the kubernetes master(s)
+  1. Run `pks cluster CLUSTER-NAME`
+  1. Look for "Kubernetes Master IP(s)"
+  1. Navigate to the [Google Cloud Platform console](https://console.cloud.google.com/).
+  1. In the sidebar menu, select **Compute Engine** > **VM instances**.
+  1. For each master ip address, filter ip address and select the one for your network
+  1. Copy the name of the master virtual machine.
+1. Update your load balancer
+  1. Navigate to the [Google Cloud Platform console](https://console.cloud.google.com/).
+  1. In the sidebar menu, select **Network Services** > **Load balancing**.
+  1. Select the load balancer you created for the cluster and select **Edit**.
+  1. Click **Backend configuration** and configure the following settings:
+  1. For each of the master virtual machine(s), select them from the dropdown.
+  <p class="note breaking"><strong>Breaking Change</strong>: If master VMs are recreated for any reason, such as a stemcell upgrade, you must reconfigure the load balancer to target the new master VMs. For more information, see the <a href="#reconfigure">Reconfigure Load Balancer</a> section below.
   1. Specify any other configuration options you require and click **Update** to complete back end configuration.
   <p class="note"><strong>Note</strong>: For clusters with multiple master node VMs, health checks on port 8443 are recommended.</p>
 


### PR DESCRIPTION
I was trying to use a PKS toolsmiths environment and I needed to
configure my load balancer. I found these steps to be super confusing.

https://docs.pivotal.io/runtimes/pks/1-4/gcp-cluster-load-balancer.html#backend
referred to
https://docs.pivotal.io/runtimes/pks/1-4/create-cluster.html#master-id
which referred to
https://docs.pivotal.io/pivotalcf/2-6/customizing/trouble-advanced.html

Yikes and too many levels of inception.

Since these directions are just for GCP, we can make them simpler

Authored-by: Todd Sedano <tsedano@pivotal.io>