### PR TITLE
Expanded on use of BOSH_ALL_PROXY

### DIFF
--- a/bbr-backup.html.md.erb
+++ b/bbr-backup.html.md.erb
@@ -61,49 +61,85 @@ For general information about the jumpbox, see [Installing BOSH Backup and Resto
 
 #### <a id='ssh'></a> Connect with SSH
 
-SSH into your jumpbox. If you connect to your jumpbox with SSH, you must run the BBR commands in
-the following sections from within your jumpbox.
+There are two options available to you to connect to your jumpbox with SSH:
+
+* Ops Manager VM.
+* SSH through the command line.
+
+1. To connect to your jumpbox through an Ops Manager VM, perform the following steps:
+    1. Log in to the Ops Manager VM:
+    1. If you are using the Ops Manager VM as your jumpbox, see the
+    [Log in to the Ops Manager VM with SSH](../trouble-advanced.html#ssh) section of _Advanced Troubleshooting with the BOSH CLI_
+    for information about how to use SSH to connect to the Ops Manager VM.
+1. To connect to your jumpbox through the CLI, perform the following steps:
+    1. Run the following command to SSH into your jumpbox:
+
+        ```
+        ssh -i LOCAL-PATH-TO-JUMPBOX-PRIVATE-KEY JUMPBOX-USER@JUMPBOX-ADDRESS
+        ```
+        Where:
+        * `LOCAL-PATH-TO-JUMPBOX-PRIVATE-KEY`  is the local path to your private key file for the jumpbox host.
+        * `JUMPBOX-USER` is your jumpbox username.
+        * `JUMPBOX-ADDRESS` is the IP address of your jumpbox.
+
+<p class="note"><strong>Note</strong>: If you connect to your jumpbox with SSH, you must run the BBR commands
+  in the following sections from within your jumpbox.</p>
+
 
 #### <a id='bosh-all-proxy'></a> Connect with BOSH&#95;ALL&#95;PROXY
 
-You can set and use `BOSH_ALL_PROXY` to open an SSH tunnel with SOCKS5 to your
-jumpbox. This tunnel enables you to forward requests to the BOSH Director through the jumpbox from
-your local machine.
+Set and use `BOSH_ALL_PROXY`. Using `BOSH_ALL_PROXY` opens an SSH tunnel with SOCKS5 to the jumpbox.
+This tunnel enables you to forward requests to the BOSH Director through the jumpbox from your local machine.
+When the environment variable `BOSH_ALL_PROXY` is set, the BBR cli will always utilise its value to forward
+requests to the BOSH Director.
 
-<p class="note"><strong>Note</strong>: When using <code>BOSH_ALL_PROXY</code> all operations must pass through the proxy. 
-Moving backup artifacts can be significantly slower, increasing backup and restore times.</p>
+Use one of the following methods to create the tunnel:
 
-1. To establish the tunnel and make it available on a local port, run the following command:
+* **Tunnel established separately**:
 
-    ```
-    ssh -4 -D PORT -fNC JUMPBOX-USER@JUMPBOX-ADDRESS -i JUMPBOX-KEYFILE -o ServerAliveInterval=60
-    ```
-    Where:
-    * `PORT` is port to use to reach the jumpbox.
-    * `JUMPBOX-USER` is the ssh username for connecting to the jumpbox.
-    * `JUMPBOX-ADDRESS` is the IP address, or hostname, of the jumpbox.
-    * `JUMPBOX-KEYFILE` is the private key file of the jumpbox.
-
-    For example:
-    <pre class="terminal">
-    $ ssh -4 -D 12345 -fNC jumpbox@203.0.113.0 -i jumpbox.key -o ServerAliveInterval=60  
-    </pre>
-
-1. To provide the BOSH CLI with access to the tunnel through use of the `BOSH_ALL_PROXY` 
-environment variable, run the following command:
+  1. To establish the tunnel and make it available on a local port, run the following command:
 
     ```
-    export BOSH_ALL_PROXY=socks5://JUMPBOX-ADDRESS:JUMPBOX-PORT
+    ssh -4 -D SOCKS-PORT -fNC JUMPBOX@JUMPBOX-IP -i JUMPBOX-KEY-FILE -o ServerAliveInterval=60
     ```
 
     Where:
-    * `JUMPBOX-ADDRESS` is the IP address of the jumpbox. 
-    * `JUMPBOX-PORT` is port to use to reach the jumpbox.
+    * `SOCKS-PORT` is the local SOCKS port.
+    * `JUMPBOX` is the name of your jumpbox.
+    * `JUMPBOX-IP` is the IP address of the jumpbox.
+    * `JUMPBOX-KEY-FILE` is the local SSH private key for accessing the jumpbox.
 
-    For example:
-    <pre class="terminal">
-    $ export BOSH&#95;ALL&#95;PROXY=socks5://203.0.113.0:12345 
-    </pre>
+  1. To provide the BOSH CLI with access to the tunnel through use of the `BOSH_ALL_PROXY` environment variable,
+  run the following command:
+
+    ```
+    export BOSH_ALL_PROXY=socks5://localhost:SOCKS-PORT
+    ```
+
+* **Tunnel created by BOSH CLI**: To provide the BOSH CLI with the SSH credentials it needs to create the
+tunnel, run the following command:
+
+    ```
+    export BOSH_ALL_PROXY=ssh+socks5://JUMPBOX@JUMPBOX-IP:SOCKS-PORT?private_key=JUMPBOX-KEY-FILE
+    ```
+
+    Where:
+    * `JUMPBOX` is the name of your jumpbox.
+    * `JUMPBOX-IP` is the IP address of the jumpbox.
+    * `SOCKS-PORT` is the local SOCKS port.
+    * `JUMPBOX-KEY-FILE` is the local SSH private key for accessing the jumpbox.
+
+
+<p class="note"><strong>Note</strong>: Ensure the SOCKS port is not already in use by a different tunnel/process.</p>
+
+<p class="note"><strong>Note</strong>: Using <code>BOSH_ALL_PROXY</code> can result in longer
+backup and restore times due to network performance degradation. Because all operations must pass
+through the proxy, moving backup artifacts can be significantly slower.</p>
+
+<div class="note warning"><strong>Warning:</strong>
+Prior to version <a href="https://github.com/cloudfoundry-incubator/bosh-backup-and-restore/releases/tag/v1.5.1">v1.5.1</a>
+of the BBR cli, the tunnel created by the BOSH cli did not include the necessary <code>ServerAliveInterval</code> flag.
+This may result in your SSH connection timing out when transferring large artifacts.</div>
 
 ### <a id='export-opsman-settings'></a> Back Up Installation Settings
 


### PR DESCRIPTION
Hey folks, we have added some more info to the BOSH_ALL_PROXY explanations, specifically:
    - added ServerAliveInterval flag in manual ssh connection example
    - version warning for potential timeouts for bbr <v1.5.1
    - rearranged order of tunnel creation methods to subtly nudge users to
    use the manual example

[#165377971]

Thanks,
Glen & @terminatingcode 