### PR TITLE
Updated LDAP/SAML instructions and beta message

### DIFF
--- a/console/console-identity-management.html.md.erb
+++ b/console/console-identity-management.html.md.erb
@@ -36,7 +36,7 @@ The procedure to add user groups to <%= vars.product_short %> Management Console
 1. Click **Add Group**. 
 1. Enter an existing LDAP or SAML user group. 
 
-   - **LDAP**: Enter the distinguished name of an existing LDAP group under the configured search base, for example `cn=admins,ou=engineering,dc=username,dc=local`.
+   - **LDAP**: Enter the distinguished name of an existing LDAP group under the configured group search base, for example `cn=admins,ou=engineering,dc=username,dc=local`.
    - **SAML**: Enter the name of your SAML identity provider group.
 1. Assign a role to the group.
    * **Cluster Manager**

--- a/console/console-identity-management.html.md.erb
+++ b/console/console-identity-management.html.md.erb
@@ -34,7 +34,10 @@ The procedure to add user groups to <%= vars.product_short %> Management Console
 1. Go to the **Identity Management** view of the management console.
 1. Select the **Groups** tab.
 1. Click **Add Group**. 
-1. Enter the name of an existing LDAP or SAML user group. 
+1. Enter an existing LDAP or SAML user group. 
+
+   - **LDAP**: Enter the distinguished name of an existing LDAP group under the configured search base, for example `cn=admins,ou=engineering,dc=username,dc=local`.
+   - **SAML**: Enter the name of your SAML identity provider group.
 1. Assign a role to the group.
    * **Cluster Manager**
    * **PKS Administrator** 

--- a/console/console-identity-management.html.md.erb
+++ b/console/console-identity-management.html.md.erb
@@ -19,7 +19,7 @@ The procedure to add individual users to <%= vars.product_short %> Management Co
 1. Select the **Users** tab.
 1. Click **Add User**. 
 1. Select **LDAP** or **UAA** depending on the configuration that you set when you deployed Enterprise PKS.
-   * If you select **LDAP**, enter a comma-separated list of email addresses for existing user accounts.
+   * If you select **LDAP**, enter a comma-separated list of user identities.  The user identities must be configured in the user search filter. The default is `CN`.
    * If you select **UAA**, enter a user name and enter and verify a password to create a new user account. 
 1. Assign a role to the user. 
    * **Cluster Manager**

--- a/console/console-index.html.md.erb
+++ b/console/console-index.html.md.erb
@@ -5,7 +5,7 @@ owner: PKS
 
 <strong><%= modified_date %></strong>
 
-<%= partial '../beta-component' %>
+<p class="note warning"><strong> WARNING:</strong> This feature is a beta component and is intended for evaluation and test purposes only. Do not use this feature in a production environment. Product support and future availability are not guaranteed for beta components.</p>
 
 VMware <%= vars.product_short %> Management Console provides a unified installation experience for deploying <%= vars.product_full %> to vSphere. The management console is provided as a virtual appliance that you deploy to vSphere by using an OVA template. The management console provides a graphical user interface that assists you with the configuration when deploying <%= vars.product_short %> to vSphere: 
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -96,7 +96,7 @@ that provides a graphical interface for deploying and managing <%= vars.product_
     </tr>
     <tr>
         <td>NSX-T versions</td>
-        <td>v2.4.0.1, v2.4.1, v2.4.2</td>
+        <td>v2.4.0.1, v2.4.1</td>
     </tr>
     <tr>
         <td>NCP version</td>
@@ -118,7 +118,7 @@ that provides a graphical interface for deploying and managing <%= vars.product_
         <li>Version 0.9 - This feature is a beta component and is intended for evaluation and test purposes only.</li>
         <li>Not released yet</li>
         <li>Supports VMware vSphere v6.5 U2 and vSphere v6.7 U2</li>
-        <li>Supports NSX-T Data Center v2.4.1 and v2.4.2</li>
+        <li>Supports NSX-T Data Center v2.4.1</li>
         <li>Installs the following components:
         <ul>
         <li>Ops Manager 2.6.5</li>


### PR DESCRIPTION
Clarified how to identify LDAP/SAML provider. Replaced the "this is a beta" warning with hard-coded text, as it wasn't showing up correctly in the VMware version of the docs.

@animatedmax can you please merge?