### PR TITLE
Change StorageClass creation process

### DIFF
--- a/volumes.html.md.erb
+++ b/volumes.html.md.erb
@@ -207,10 +207,6 @@ For the Deployment workload with dynamic PV provisioning, the procedure is as fo
     metadata:
       name: thin-disk
     provisioner: kubernetes.io/vsphere-volume
-    parameters:
-    	datastore: Datastore-NFS-VM
-    	diskformat: thin
-    	fstype: ext3
     ```
 
 1. Define a PVC using a YAML manifest file that references the StorageClass. For example, create a file named `redis-master-claim.yaml` with the following contents:
@@ -262,10 +258,6 @@ To provision a static PV for a StatefulSets workload with three replicas, the pr
     metadata:
       name: my-storage-class
     provisioner: kubernetes.io/vsphere-volume
-    parameters:
-    	datastore: Datastore-NFS-VM
-    	diskformat: thin
-    	fstype: ext3
     ```
 
 1. Define a StatefulSets object using a YAML manifest file that references the StorageClass. For example, create a file named `mysql-statefulsets.yaml` with the following contents:
@@ -307,10 +299,6 @@ metadata:
   annotations:
 	storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/vsphere-volume
-parameters:
-	datastore: Datastore-NFS-VM
-	diskformat: thin
-	fstype: ext3
 ```
 
 <p class="note"><strong>Note</strong>: The above example uses the vSphere provisioner. Refer to the <a href="https://kubernetes.io/docs/concepts/storage/storage-classes/#provisioner">Kubernetes documentation</a> for information about provisioners for other cloud providers.</p>
@@ -337,8 +325,6 @@ Perform the steps in this section to register one or more StorageClasses and def
           annotations:
             storageclass.kubernetes.io/is-default-class: "true"
         provisioner: kubernetes.io/vsphere-volume
-        parameters:
-            diskformat: thin
         ```
 
 1. Apply the spec by running `kubectl create -f STORAGE-CLASS-SPEC.yml`.


### PR DESCRIPTION
When you create a StorageClass on vSphere, there is no need to specify:

- datastore
- diskformat
- fstype

The PKS tile is configured with defaults that you can use for the datastore, and kubectl contains defaults for the [others](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html). The person that configures the storageclass may not have any idea what a datastore is, or what it _might_ be named. Ditto for diskformat and fstype.

This change removes the over-complicated example.