### PR TITLE
Adds additional details about Node Exporter

### DIFF
--- a/monitor-etcd.html.md.erb
+++ b/monitor-etcd.html.md.erb
@@ -77,7 +77,8 @@ To connect a monitoring service to etcd, do the following:
 
     ![Monitoring pane](images/monitoring.png)
 
-1. (Optional) If you want to send metrics from Node Exporter, select **Enable Node-Exporter on master**
+1. (Optional) If you want to send metrics from Node Exporter, select **Enable Node-Exporter on master**. 
+This will expose a [wide variety of node metics](https://github.com/prometheus/node_exporter#enabled-by-default).
 
 
 1. For **Setup Telegraf Outputs**, enter the contents of the configuration file

--- a/sink-architecture.html.md.erb
+++ b/sink-architecture.html.md.erb
@@ -58,7 +58,7 @@ Deployment metrics are monitored by a set of third-party plugins. The plugins fo
 
 A pair of kubelets monitor Kubernetes and forward Kubernetes metrics to a pair of Telegraph service pods. 
 
-If Node Exporter is enabled in the <%= vars.product_tile %> tile, Node Exporter forwards infrastructure metrics to Telegraph service pods.
+If Node Exporter is enabled on the worker nodes from with the <%= vars.product_tile %>  a Node Exporter deamonset will be included in all clusters, exposing a [wide variety of node metics](https://github.com/prometheus/node_exporter#enabled-by-default).
 
 To define the collected unstructured metrics, a metric-controller monitors Kubernetes for custom resource definitions and forwards those definitions 
 to the Telegraph services. 
@@ -80,7 +80,7 @@ A metric sink for a master node writes BOSH health metrics from a cluster to spe
 
 The etcd server exports metrics from a `/metrics` endpoint to the Telegraph services.
 
-If Node Exporter is enabled in the <%= vars.product_tile %> tile, Node Exporter forwards infrastructure metrics to Telegraph service pods. 
+If Node Exporter is enabled on the master nodes the <%= vars.product_tile %> form within the tile, a Node Exporter job will run on the master vms and expose [wide variety of node metics](https://github.com/prometheus/node_exporter#enabled-by-default) to the Telegraf agent. 
 
 Kubernetes forwards custom resource definitions to the Telegraph services.
 


### PR DESCRIPTION
This PR adds additional detail about the Node Exporter and how it works on both master and workers. It does not yet include changes to references in the install instructions (e.g. [GCP](https://docs.pivotal.io/pks/1-5/installing-pks-gcp.html))