### PR TITLE
Sink changes for 1.6 beta

### DIFF
--- a/create-sinks.html.md.erb
+++ b/create-sinks.html.md.erb
@@ -30,19 +30,6 @@ for your IaaS:
 * [Installing <%= vars.product_short %> on AWS](installing-pks-aws.html)
 * [Installing <%= vars.product_short %> on Azure](installing-pks-azure.html)
 
-### <a name='cli-prereqs'></a> CLI Requirements
-
-To create and manage sink resources, you must install the Kubernetes CLI, <code>kubectl</code>. 
-
-Alternately, to manage `ClusterLogSink` resources with the PKS CLI, you must use PKS CLI v1.3 or later.
-
-<p class="note"><strong>Note:</strong> The <code>pks create-sink</code>, <code>pks sinks</code>, and <code>pks delete-sink</code> commands
-are deprecated in the PKS CLI. <%= vars.product_short %> will remove these commands in a future release. You can use the Kubernetes CLI for creating and managing <code>ClusterLogSink</code> resources instead.
-For more information, see <a href="release-notes.html#sink-cli-deprecation">Deprecation of Sink Commands in the PKS CLI</a>.</p>
-
-For installation instructions, see <a href="installing-kubectl-cli.html">Installing the Kubernetes CLI</a> 
-and <a href="installing-pks-cli.html">Installing the PKS CLI</a>.
-
 ## <a id='define-resource'></a>Create Sinks
 
 You can create log and metric sinks for clusters and namespaces.
@@ -64,7 +51,6 @@ You can create log and metric sinks for clusters and namespaces.
 
 To create and manage `ClusterLogSink` resources, you can:
 
-* [Create ClusterLogSink Resource with the PKS CLI](#cluster-sink-pks)
 * [Create a Syslog ClusterLogSink Resource with YAML and kubectl](#syslog-cluster-sink)
 * [Create a Webhook ClusterLogSink Resource with YAML and kubectl](#webhook-cluster-sink)
 
@@ -74,49 +60,6 @@ for log forwarding. To forward logs using an unsecured connection, see
 
 #### <a id='cluster-sink-pks'></a> Create ClusterLogSink Resource with the PKS CLI
 
-To create and apply a log sink to a cluster, run the following command:
-
-```
-pks create-sink CLUSTER-NAME \
-syslog-tls://YOUR-LOG-DESTINATION:YOUR-LOG-DESTINATION-PORT
-```
-Where:
-
-* `CLUSTER-NAME` is the name of your cluster.
-* `YOUR-LOG-DESTINATION` is the URL or IP address of your log management service.
-* `YOUR-LOG-DESTINATION-PORT` is the port number of your log management service.
-
-For example:
-
-<pre class="terminal">
-$ pks create-sink my-cluster syslog-tls://example.com:12345
-</pre>
-
-If you do not specify a name, the command creates 
-a log sink resource in the cluster that shares the same name as the cluster.
-
-To provide a name for the log sink resources in your cluster, run the following command. 
-
-```
-pks create-sink CLUSTER-NAME --name YOUR-SINK \
-syslog-tls://YOUR-LOG-DESTINATION:YOUR-LOG-DESTINATION-PORT
-```
-Where:
-
-* `CLUSTER-NAME` is the name of your cluster.
-* `YOUR-SINK` is the name of the log sink you want to create.
-* `YOUR-LOG-DESTINATION` is the URL or IP address of your log management service.
-* `YOUR-LOG-DESTINATION-PORT` is the port number of your log management service.
-
-For example:
-
-<pre class="terminal">
-$ pks create-sink my-cluster --name second-sink syslog-tls://example.org:54321
-</pre>
-
-Specifying a name is useful if you need to manage multiple log sink resources in your cluster.
-
-#### <a id='syslog-cluster-sink'></a> Create a Syslog ClusterLogSink Resource with YAML and kubectl
 
 A syslog `ClusterLogSink` resource delivers logs using the TCP-based syslog protocol.
 
@@ -196,8 +139,6 @@ You can use only `kubectl` to create and manage log sinks for namespaces.
 
 #### <a id='sink-kubectl'></a> Create a LogSink Resource with YAML and kubectl
 
-To define a `LogSink` resource with YAML and `kubectl`, perform the following steps:
-
 1. Create a YAML file that specifies your log destination in the following format:
 
     ```
@@ -243,6 +184,42 @@ To forward `ClusterLogSink` and `LogSink` logs using an unsecured connection, yo
     kubectl delete validatingwebhookconfigurations validator.pksapi.io
     ```
 <p class="note warning"><strong>Warning:</strong> Disabling secure log forwarding is not recommended.</p>
+
+### <a id='logsink-output-plugin'></a> Log Sink Output Plugins.
+
+To define a `ClusterLogSink` or `LogSink` resource with a custom output plugin, perform the following steps:
+1.    Create a YAML file that specifies your log destination in the following format: 
+
+```
+apiVersion: pksapi.io/v1beta1
+kind: ClusterLogSink
+metadata:
+  name: YOUR-SINK-NAME
+spec:
+  type: http
+  output_properties:
+    Host: example.com
+    Format: json
+    Port: 443
+    tls: on
+    tls.verify: off
+```
+Note:
+* This is a sample plugin. For a full list of plugins see the [FluentBit documentation](https://docs.fluentbit.io/manual/v/1.3/output). 
+
+1. Save the YAML file with an appropriate filename. For example, `my-cluster-sink.yml`.
+
+1. Apply the `ClusterLogSink` resource to your cluster by running the following command:
+
+    ```
+    kubectl apply -f MY-SINK.yml
+    ```
+    Where `MY-SINK.yml` is the name of your YAML file.
+    For example:
+    <pre class='terminal'>
+    $ kubectl apply -f my-cluster-sink.yml
+    </pre>
+
 
 ### <a id='define-cluster-metric-sink'></a> ClusterMetricSink Resources
 


### PR DESCRIPTION
This PR covers two changes expected to be included in the 1.6 Beta tile build. These are

1. Removes the pks sink CLI commands. (We issued a deprecation warning last release)
1. Adds multiple output plugins for log sinks. 