### PR TITLE
Update telegraf docs link to installed version

### DIFF
--- a/create-sinks.html.md.erb
+++ b/create-sinks.html.md.erb
@@ -226,7 +226,7 @@ A `ClusterMetricSink` resource collects metrics from a cluster using the [Kubern
 (https://github.com/influxdata/telegraf/tree/1.9.3/#input-plugins) and writes them to one or more outputs
 that you specify in the configuration of your `ClusterMetricSink`.
 For a list of supported metrics and output plugins,
-see [Metrics](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/kubernetes#metrics)
+see [Metrics](https://github.com/influxdata/telegraf/tree/1.9.3/plugins/inputs/kubernetes#metrics)
 and [Output Plugins](https://github.com/influxdata/telegraf/tree/1.9.3/#output-plugins) in the telegraf GitHub repository.
 
 Currently, you can use only `kubectl` to create and manage metric sinks for clusters.


### PR DESCRIPTION
Telegraf 1.9.3 is used on PKS 1.4, link to Metrics from that version in docs

https://www.pivotaltracker.com/story/show/169236607