### PR TITLE
Comment out the Management Console sections until 1.1 GA

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -189,34 +189,34 @@ see [Ingress Scaling (NSX-T only)](nsxt-ingress-scale.html).
 
 ### <a id='1-6-0-console-snapshot'></a>VMware Enterprise PKS Management Console Product Snapshot
 
-<p class="note"><strong>Note</strong>: The Management Console BETA provides an opinionated installation of <%= vars.product_short %>. The supported versions list may differ from or be more limited than what is generally supported by <%= vars.product_short %>.</p>
+<p class="note"><strong>Note</strong>: Enterprise PKS Management Console provides an opinionated installation of Enterprise PKS. The supported versions may differ from or be more limited than what is generally supported by Enterprise PKS.</p>
 
 <table class="nice">
     <th>Element</th>
     <th>Details</th>
     <tr>
       <td>Version</td>
-      <td>v0.9 - This feature is a beta component and is intended for evaluation and test purposes only.</td>
+      <td>v1.0.0</td>
     </tr>
     <tr>
       <td>Release date</td>
-      <td>August 22, 2019</td>
+      <td>October 16, 2019</td>
     </tr>
     <tr>
       <td>Installed Enterprise PKS version</td>
-      <td>v1.6.0</td>
+      <td>v1.5.1</td>
     </tr>
     <tr>
       <td>Installed Ops Manager version</td>
-      <td>v2.6.5</td>
+      <td>v2.6.11</td>
     </tr>
     <tr>
       <td>Installed Kubernetes version</td>
-        <td>v1.14.5</td>
+        <td>v1.14.6</td>
     </tr>
     <tr>
       <td>Supported NSX-T versions</td>
-      <td>v2.4.1, v2.4.2 (<a href="./release-notes.html#nsxt-242">see below</a>)</td>
+      <td>v2.5.0, v2.4.2 (<a href="./release-notes.html#nsxt-242">see below</a>), v2.4.1</td>
     </tr>
     <tr>
       <td>Installed Harbor Registry version</td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -186,7 +186,7 @@ see [Ingress Scaling (NSX-T only)](nsxt-ingress-scale.html).
     </tr>
    </tr>
 </table>
-
+<!--
 ### <a id='1-6-0-console-snapshot'></a>VMware Enterprise PKS Management Console Product Snapshot
 
 <p class="note"><strong>Note</strong>: Enterprise PKS Management Console provides an opinionated installation of Enterprise PKS. The supported versions may differ from or be more limited than what is generally supported by Enterprise PKS.</p>
@@ -223,7 +223,7 @@ see [Ingress Scaling (NSX-T only)](nsxt-ingress-scale.html).
       <td>v1.8.1</td>
     </tr>
 </table>
-
+-->
 
 ### <a id='vsphere-reqs'></a> vSphere Version Requirements
 
@@ -265,7 +265,8 @@ For example, instead of `https://YOUR-PKS-API-FQDN:9021/v1beta1/quotas`, use `ht
 ###<a id='1-6-0-known-issues'></a> Known Issues
 
 <%= vars.product_short %> v1.6.0 has no known issues.  
-
+<!--
 ###<a id='1-6-0-known-issues-management-console'></a> Enterprise PKS Management Console Known Issues
 
 <%= vars.product_short %> Management Console v0.9.0 appliance and user interface has no known issues.
+-->

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -216,7 +216,7 @@ see [Ingress Scaling (NSX-T only)](nsxt-ingress-scale.html).
     </tr>
     <tr>
       <td>Supported NSX-T versions</td>
-      <td>v2.5.0, v2.4.2 (<a href="./release-notes.html#nsxt-242">see below</a>), v2.4.1</td>
+      <td>v2.5.0, v2.4.2, v2.4.1</td>
     </tr>
     <tr>
       <td>Installed Harbor Registry version</td>


### PR DESCRIPTION
I noticed that the staged RNs for PKS 1.6 include the info about Management Console 0.9. Updated to the 1.0.0 info.

I will update the RNs with 1.1 info once Console 1.1 is released.

**UPDATE**: Following discussion with @anishmehta1 and @lparis, we decided to completely comment out the Console sections until 1.1 is released.