### PR TITLE
Removing console from 1.6 RNs

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -188,44 +188,6 @@ see [Ingress Scaling (NSX-T only)](nsxt-ingress-scale.html).
     </tr>
    </tr>
 </table>
-<%#
-### <a id='1-6-0-console-snapshot'></a>VMware Enterprise PKS Management Console Product Snapshot
-
-<p class="note"><strong>Note</strong>: Enterprise PKS Management Console provides an opinionated installation of Enterprise PKS. The supported versions may differ from or be more limited than what is generally supported by Enterprise PKS.</p>
-
-<table class="nice">
-    <th>Element</th>
-    <th>Details</th>
-    <tr>
-      <td>Version</td>
-      <td>v1.0.0</td>
-    </tr>
-    <tr>
-      <td>Release date</td>
-      <td>October 16, 2019</td>
-    </tr>
-    <tr>
-      <td>Installed Enterprise PKS version</td>
-      <td>v1.5.1</td>
-    </tr>
-    <tr>
-      <td>Installed Ops Manager version</td>
-      <td>v2.6.11</td>
-    </tr>
-    <tr>
-      <td>Installed Kubernetes version</td>
-        <td>v1.14.6</td>
-    </tr>
-    <tr>
-      <td>Supported NSX-T versions</td>
-      <td>v2.5.0, v2.4.2, v2.4.1</td>
-    </tr>
-    <tr>
-      <td>Installed Harbor Registry version</td>
-      <td>v1.8.1</td>
-    </tr>
-</table>
-%>
 
 ### <a id='vsphere-reqs'></a> vSphere Version Requirements
 
@@ -461,10 +423,3 @@ You can safely configure and use **Plan 4**.
 The length of the **Plan 4** ID does not affect the functionality of **Plan 4** clusters.
 
 If you require all plan IDs to have identical length, do not activate or use **Plan 4**.
-
-<%#
-###<a id='1-6-0-known-issues-management-console'></a> Enterprise PKS Management Console Known Issues
-
-<%= vars.product_short %> 
-<%# Management Console v0.9.0 appliance and user interface has no known issues.
-%>


### PR DESCRIPTION
The console content was suppressed, but links are still showing up in the sub-menu on the right:

![console-index](https://user-images.githubusercontent.com/16718369/68928259-f2953480-0789-11ea-90b8-f69ebc8f1cc6.png)

This PR removes the console content completely.