### PR TITLE
Add backup and restore recommendations

### DIFF
--- a/bbr-backup.html.md.erb
+++ b/bbr-backup.html.md.erb
@@ -19,6 +19,18 @@ To perform a restore, see [Restoring the <%= vars.product_short %> Control Plane
 
 To view the BBR release notes, see the Cloud Foundry documentation, [BOSH Backup and Restore Release Notes](https://docs.cloudfoundry.org/bbr/bbr-rn.html).
 
+## <a id='recs'></a> Recommendations
+
+Pivotal recommends:
+
+* Follow the full procedure documented in this topic when creating a backup. This ensures that you always have a consistent backup of Pivotal Operations Manager and <%= vars.product_short %> to restore from.
+
+* Back up frequently, especially before upgrading your <%= vars.product_short %> deployment.
+
+* For BOSH v270.0 and above (currently available in PCF 2.7), you can prune the BOSH blobstore by running `bosh clean-up --all` prior to running a backup of the BOSH director. This will remove all unused resources including packages compiled against older stemcell versions. This will result in a smaller, faster backup of the BOSH director if a lot of unused resources have accumulated over time. For more information see [Clean-Up](https://bosh.io/docs/cli-v2/#clean-up).
+
+<p class="note"><strong>Note:</strong>The command `bosh clean-up --all` is a destructive operation and can remove resources that are unused but needed. For example, if an On-Demand Service Broker such as <%= vars.product_short %> is deployed <strong>and</strong> no service instances have been created, the releases needed to create a service instance will be categorised as unused and removed.</p>
+
 ## <a id='supported'></a> Supported Components
 
 BBR can backup the following components:


### PR DESCRIPTION
This informs operators that they can run a clean-up operation prior to performing a BOSH director backup. It is accompanied by a warning note that this operation is destructive and to be aware of the potential damage.

Story [here](https://www.pivotaltracker.com/story/show/166407001)

cc @totherme