### PR TITLE
Feedback docker custom certs

### DIFF
--- a/docker-custom-ca-certs.html.md.erb
+++ b/docker-custom-ca-certs.html.md.erb
@@ -174,7 +174,7 @@ your certificate string must be provided without newline wrapping.
 
 To prepare your certificate string for command line use: 
 
-1. To remove your newline characters from a certificate string, run the following command:  
+1. To remove newline wrapping from a certificate string, run the following command:  
 
     ```
     awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}'  CA-PEM
@@ -182,4 +182,4 @@ To prepare your certificate string for command line use:
 
     Where `CA-PEM` is the filename of your PEM-formatted CA certificate file.  
 <br>
-    This command returns your certificate string with all `\n` newline characters removed.   
+    This command returns your certificate string without newline wrapping.   

--- a/docker-custom-ca-certs.html.md.erb
+++ b/docker-custom-ca-certs.html.md.erb
@@ -71,7 +71,7 @@ using the PKS API `create-cluster` endpoint.
     curl -X POST \
       https://PKS-API:9021/v1/clusters \
       -H 'Accept: application/json' \
-      -H 'Authorization: Bearer $YOUR-ACCESS-TOKEN' \
+      -H "Authorization: Bearer $YOUR-ACCESS-TOKEN" \
       -H 'Content-Type: application/json' \
       -H 'Host: PKS-API:9021' \
       -d '{
@@ -118,7 +118,7 @@ You can update an existing cluster with one or more SSL CA certificates by using
     curl -X PATCH \
       https://PKS-API:9021/v1/clusters/CLUSTER-NAME \
       -H 'Accept: application/json' \
-      -H 'Authorization: Bearer $YOUR-ACCESS-TOKEN' \
+      -H "Authorization: Bearer $YOUR-ACCESS-TOKEN" \
       -H 'Content-Type: application/json' \
       -H 'Host: PKS-API:9021' \
       -d '{

--- a/docker-custom-ca-certs.html.md.erb
+++ b/docker-custom-ca-certs.html.md.erb
@@ -53,6 +53,10 @@ For more information about securing a private Docker registry, see
 [Use self-signed certificates](https://docs.docker.com/registry/insecure/#use-self-signed-certificates)
 in the _Docker Registry_ manual.
 
+<p class="note warning">
+<strong>Warning: </strong> The FQDN for the private Docker registry cannot contain a hyphen, dash, or semi-colon. If such a character is included in the registry name the PKS API will reject it as not a valid character.
+</p>
+
 ## <a id='set-token'></a> Set up Your API Access Token
 
 The curl commands in this topic use an access token environment variable to


### PR DESCRIPTION
Feedback received:
1) The authorization header which contains the token needs to be double quotes, not single. (Follow up with Lorenzo to correct docs)
2) Improve wording of https://docs.pivotal.io/pks/1-6/docker-custom-ca-certs.html#preparing-certificate as "\n" are added, not removed. (Follow up with Lorenzo)
3) FQDN for the private registry cannot contain a hyphen/single-dash "-" or a semi-colon (so can specify a port number) as the PKS API will reject it as not a valid character. Follow up with Lorenzo to update docs

This PR addresses #s 1 and 3. #2 I am not sure about since the purpose here is to remove the new lines chars so that the cert can be used on the command line. If the command we are providing is actually adding new line characters then we need to fix the command not the docs. Need to follow up with the feedback person. For now please merge to adress #s 1 and 3. Thanks.