### PR TITLE
Removed 2 rows from ports table

### DIFF
--- a/console/console-ports-protocols.html.md.erb
+++ b/console/console-ports-protocols.html.md.erb
@@ -30,5 +30,3 @@ If you are unable to implement your security policy using these methods, refer t
 | Management Console Appliance VM | Pivotal Cloud Foundry Operations Manager | TCP | 443 | https |
 | Management Console Appliance VM | PKS Controller | TCP | 9021 | pks api server |
 | Management Console Appliance VM | vCenter Server | TCP | 443 | https |
-| Management Console Appliance VM | vCenter Server | TCP | 5480 | vami |
-| Management Console Appliance VM | vSphere ESXI Hosts Mgmt. vmknic | TCP | 902 | ideafarm-door |


### PR DESCRIPTION
Per comment from Vui via Slack: "just took a look at https://docs-pcf-staging.cfapps.io/pks-patches/1-6/console/console-ports-protocols.html, the last two rows (ideafarm-door and vami) we don't need"