### PR TITLE
Remove stretech cluster use case from host group

### DIFF
--- a/vsphere-host-group.html.md.erb
+++ b/vsphere-host-group.html.md.erb
@@ -20,14 +20,6 @@ For more information on vSphere host groups, refer to the [vSphere documentation
 
 This subsection describes use cases for using host groups with <%= vars.product_short %>.
 
-### Enabling Support for vSphere Stretched Clusters
-
-A stretched cluster is a single compute cluster that spans two physical datacenters. vSAN is "stretched" to provide storage for the single compute cluster across both physical datacenters. 
-
-Host groups support stretched clusters. Kubernetes nodes disks components and PVs will be replicated across the two sites. Kubernetes node VMs can be placed in one site or in both, depending on how the plan is configured (1 AZ checked or 2 AZs checked).
-
-<p class="note"><strong>Note</strong>: <%= vars.product_short %> supports the default Storage Policy Based Management set on vCenter for vSAN. The number of <strong>Failures to Tolerate</strong> (FTT) must be set to 1 to perform data replication across the two sites.</p>
-
 ### Enabling Support for vSAN Fault Domains
 
 The vSAN fault domains feature instructs vSAN to spread redundancy components across the servers in separate computing racks. In this way, you can protect the environment from a rack-level failure such as loss of power or connectivity. For more information, see [Designing and Sizing vSAN Fault Domains


### PR DESCRIPTION
Remove stretched cluster from 1.6 docs. (It was already removed from 1.5 docs.)