### PR TITLE
Added RNs for console 1.6.0-rev.3 and grouped all console info

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -527,7 +527,7 @@ or [Creating a Windows Stemcell for vSphere Using stembuild (Beta)](https://docs
       
 ## <a id="management-console-1.6.0-rev3"></a> <%= vars.product_short %> Management Console 1.6.0-rev.3
 
-**Release Date**: December xx, 2019
+**Release Date**: December 19, 2019
 
 ### <a id="management-console-1.6.0-rev3-features"></a>Features
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -101,18 +101,6 @@ see [Ingress Scaling (NSX-T only)](nsxt-ingress-scale.html).
 * Support for HTTP/HTTPS Proxy on AWS. For more information see, [Using Proxies with <%= vars.product_short %> on AWS](proxies-aws.html).  
 
 
-#### <a id="management-console"></a> Enterprise PKS Management Console v1.6.0-rev.2
-
-<%= vars.product_short %> Management Console v1.6.0-rev.2 updates include:
-
-* Provides experimental integration with VMware Tanzu Mission Control. For more information, see [Tanzu Mission Control Integration](./console/deploy-ent-pks-wizard.html#integrations-tanzumc).
-* Provides experimental support for plans that use Windows worker nodes. For information, see [Configure Plans](./console/deploy-ent-pks-wizard.html#plans).
-* Deploys Harbor registry v1.9. For information, see [Configure Harbor](./console/deploy-ent-pks-wizard.html#harbor).
-* Adds support for active-active mode on the tier 0 router in automated-NAT deployments and No-NAT configurations in Bring Your Own Topology deployments.  For information, see [Configure Networking](./console/deploy-ent-pks-wizard.html#networking).
-* Adds the ability to configure proxies for the integration with Wavefront. For information, see [Configure a Connection to Wavefront](./console/deploy-ent-pks-wizard.html#integrations-wavefront).
-* Adds the ability to configure the size of the PKS API VM. For information, see [Configure Resources and Storage](./console/deploy-ent-pks-wizard.html#storage).
-* Allows you to use the management console to upgrade to v1.6.0-rev.2. For information, see [Upgrade <%= vars.product_short %> Management Console](./console/upgrade-console.html).
-
 #### <a id="telemetry"></a> Customer Experience Improvement Program
 
 <%= vars.product_short %> v1.6.0 updates include:
@@ -199,43 +187,6 @@ see [Ingress Scaling (NSX-T only)](nsxt-ingress-scale.html).
         <td>v73.4.8</td>
     </tr>
    </tr>
-</table>
-
-### <a id='1-6-0-console-snapshot'></a>VMware Enterprise PKS Management Console Product Snapshot
-
-<p class="note"><strong>Note</strong>: Enterprise PKS Management Console provides an opinionated installation of Enterprise PKS. The supported versions may differ from or be more limited than what is generally supported by Enterprise PKS.</p>
-
-<table class="nice">
-    <th>Element</th>
-    <th>Details</th>
-    <tr>
-      <td>Version</td>
-      <td>v1.6.0-rev.2</td>
-    </tr>
-    <tr>
-      <td>Release date</td>
-      <td>November 26, 2019</td>
-    </tr>
-    <tr>
-      <td>Installed Enterprise PKS version</td>
-      <td>v1.6.0</td>
-    </tr>
-    <tr>
-      <td>Installed Ops Manager version</td>
-      <td>v2.7.3</td>
-    </tr>
-    <tr>
-      <td>Installed Kubernetes version</td>
-        <td>v1.15.5</td>
-    </tr>
-    <tr>
-      <td>Supported NSX-T versions</td>
-      <td>v2.5.0, v2.4.3</td>
-    </tr>
-    <tr>
-      <td>Installed Harbor Registry version</td>
-      <td>v1.9.3</td>
-    </tr>
 </table>
 
 ### <a id='vsphere-reqs'></a> vSphere Version Requirements
@@ -573,12 +524,125 @@ or [Creating a Windows Stemcell for vSphere Using stembuild (Beta)](https://docs
 1. Upload your new stemcell to your <%= vars.product_tile %> tile.  
 1. Delete your existing Windows clusters. For information about deleting clusters see [Deleting Clusters](delete-cluster.html).   
 1. Redeploy your Windows clusters. For information about deploying clusters see [Creating Clusters](create-cluster.html).  
+      
+## <a id="management-console-1.6.0-rev3"></a> <%= vars.product_short %> Management Console 1.6.0-rev.3
 
-### <a id="1-6-0-management-console-1-1-known-issues"></a> Enterprise PKS Management Console Known Issues
+**Release Date**: December xx, 2019
+
+### <a id="management-console-1.6.0-rev3-features"></a>Features
+
+<%= vars.product_short %> Management Console 1.6.0-rev.3 has no new features.
+
+### <a id="management-console-1.6.0-rev3-bug-fixes"></a>Bug Fixes
+
+<%= vars.product_short %> Management Console 1.6.0-rev.3 includes the following bug fixes:
+
+- Fixes UI failure caused by multiple datacenters being present in vCenter Server.
+- Adds support for both FQDN and IP addresses in LDAP/LDAPS configuration for identity management. 
+- Fixes UI freezing after entering unconventionally formatted URLs for SAML provider metadata.
+- Adds support for UAA role `pks.clusters.admin.read` in identity Management configuration.
+- Adds validation for Harbor FQDN in lower case.
+- Fixes misconfigured Wavefront HTTP Proxy when field is left empty.
+
+### <a id="management-console-1.6.0-rev3-snapshot"></a>Product Snapshot
+
+<p class="note"><strong>Note</strong>: <%= vars.product_short %> Management Console provides an opinionated installation of <%= vars.product_short %>. The supported versions may differ from or be more limited than what is generally supported by <%= vars.product_short %>.</p>
+
+<table class="nice">
+    <th>Element</th>
+    <th>Details</th>
+    <tr>
+      <td>Version</td>
+      <td>v1.6.0-rev.3</td>
+    </tr>
+    <tr>
+      <td>Release date</td>
+      <td>December XX, 2019</td>
+    </tr>
+    <tr>
+      <td>Installed Enterprise PKS version</td>
+      <td>v1.6.0</td>
+    </tr>
+    <tr>
+      <td>Installed Ops Manager version</td>
+      <td>v2.7.3</td>
+    </tr>
+    <tr>
+      <td>Installed Kubernetes version</td>
+        <td>v1.15.5</td>
+    </tr>
+    <tr>
+      <td>Supported NSX-T versions</td>
+      <td>v2.5.0, v2.4.3</td>
+    </tr>
+    <tr>
+      <td>Installed Harbor Registry version</td>
+      <td>v1.9.3</td>
+    </tr>
+</table>
+
+### <a id="management-console-1.6.0-rev3-known-issues"></a> Known Issues
+
+With the exception of the [Bug Fixes](#management-console-1.6.0-rev3-bug-fixes) listed above, the <%= vars.product_short %> Management Console v1.6.0-rev.3 appliance and user interface have the same [known issues](#management-console-1.6.0-rev2-known-issues) as v1.6.0-rev.2.
+
+## <a id="management-console-1.6.0-rev2"></a> <%= vars.product_short %> Management Console v1.6.0-rev.2
+
+**Release Date**: November 26, 2019
+
+### <a id="management-console-1.6.0-rev2-features"></a>Features
+
+<%= vars.product_short %> Management Console v1.6.0-rev.2 updates include:
+
+* Provides experimental integration with VMware Tanzu Mission Control. For more information, see [Tanzu Mission Control Integration](./console/deploy-ent-pks-wizard.html#integrations-tanzumc).
+* Provides experimental support for plans that use Windows worker nodes. For information, see [Configure Plans](./console/deploy-ent-pks-wizard.html#plans).
+* Deploys Harbor registry v1.9. For information, see [Configure Harbor](./console/deploy-ent-pks-wizard.html#harbor).
+* Adds support for active-active mode on the tier 0 router in automated-NAT deployments and No-NAT configurations in Bring Your Own Topology deployments.  For information, see [Configure Networking](./console/deploy-ent-pks-wizard.html#networking).
+* Adds the ability to configure proxies for the integration with Wavefront. For information, see [Configure a Connection to Wavefront](./console/deploy-ent-pks-wizard.html#integrations-wavefront).
+* Adds the ability to configure the size of the PKS API VM. For information, see [Configure Resources and Storage](./console/deploy-ent-pks-wizard.html#storage).
+* Allows you to use the management console to upgrade to v1.6.0-rev.2. For information, see [Upgrade <%= vars.product_short %> Management Console](./console/upgrade-console.html).
+
+### <a id="management-console-1.6.0-rev2-snapshot"></a>Product Snapshot
+
+<p class="note"><strong>Note</strong>: Enterprise PKS Management Console provides an opinionated installation of Enterprise PKS. The supported versions may differ from or be more limited than what is generally supported by Enterprise PKS.</p>
+
+<table class="nice">
+    <th>Element</th>
+    <th>Details</th>
+    <tr>
+      <td>Version</td>
+      <td>v1.6.0-rev.2</td>
+    </tr>
+    <tr>
+      <td>Release date</td>
+      <td>November 26, 2019</td>
+    </tr>
+    <tr>
+      <td>Installed Enterprise PKS version</td>
+      <td>v1.6.0</td>
+    </tr>
+    <tr>
+      <td>Installed Ops Manager version</td>
+      <td>v2.7.3</td>
+    </tr>
+    <tr>
+      <td>Installed Kubernetes version</td>
+        <td>v1.15.5</td>
+    </tr>
+    <tr>
+      <td>Supported NSX-T versions</td>
+      <td>v2.5.0, v2.4.3</td>
+    </tr>
+    <tr>
+      <td>Installed Harbor Registry version</td>
+      <td>v1.9.3</td>
+    </tr>
+</table>
+
+### <a id="management-console-1.6.0-rev2-known-issues"></a>Known Issues
 
 The following known issues are specific to the <%= vars.product_short %> Management Console v1.6.0-rev.2 appliance and user interface.
 
-#### <a id="1-6-0-management-console-1-1-yaml-validation"></a>YAML Validation Errors Not Cleared
+#### <a id="management-console-1.6.0-rev2-yaml-validation"></a>YAML Validation Errors Not Cleared
 
 **Symptom**
 
@@ -592,7 +656,7 @@ The validation errors are not cleared when you resubmit the YAML configuration f
 
 None
 
-#### <a id="1-6-0-management-console-1-1-notifications"></a><%= vars.product_short %> Management Console Notifications Persist
+#### <a id="management-console-1.6.0-rev2-notifications"></a><%= vars.product_short %> Management Console Notifications Persist
 
 **Symptom**
 
@@ -606,7 +670,7 @@ After clicking the **X** button to clear a notification it is removed, but when 
 
 Use shift+refresh to reload the page.
 
-#### <a id="1-6-0-management-console-1-1-delete-deployment"></a>Cannot Delete <%= vars.product_short %> Deployment from Management Console
+#### <a id="management-console-1.6.0-rev2-delete-deployment"></a>Cannot Delete <%= vars.product_short %> Deployment from Management Console
 
 **Symptom**
 
@@ -620,7 +684,7 @@ The option to delete the deployment is only activated in the management console 
 
 After removing clusters, wait for a few minutes before attempting to use the **Delete Enterprise PKS Deployment** option again.
 
-#### <a id="1-6-0-management-console-1-1-vli-port"></a>Configuring <%= vars.product_short %> Management Console Integration with VMware vRealize Log Insight
+#### <a id="management-console-1.6.0-rev2-vli-port"></a>Configuring <%= vars.product_short %> Management Console Integration with VMware vRealize Log Insight
 
 **Symptom**
 
@@ -634,7 +698,7 @@ When you deploy the Enterprise PKS Management Console appliance from the OVA, if
 
 Set the vRealize Log Insight port to the HTTP port. This is typically port `9000`.
 
-#### <a id="1-6-0-management-console-1-1-nsxt-flannel-error"></a>Deploying <%= vars.product_short %> to an Unprepared NSX-T Data Center Environment Results in Flannel Error
+#### <a id="management-console-1.6.0-rev2-nsxt-flannel-error"></a>Deploying <%= vars.product_short %> to an Unprepared NSX-T Data Center Environment Results in Flannel Error
 
 **Symptom**
 
@@ -648,7 +712,7 @@ The network configuration has failed, but the error message is incorrect.
 
 To see the correct reason for the failure, see the server logs. For instructions about how to obtain the server logs, see [Troubleshooting Enterprise PKS Management Console](./console/console-troubleshooting.html).
 
-#### <a id="1-6-0-management-console-1-1-bosh-cli"></a>Using BOSH CLI from Operations Manager VM
+#### <a id="management-console-1.6.0-rev2-bosh-cli"></a>Using BOSH CLI from Operations Manager VM
 
 **Symptom**
 
@@ -667,7 +731,7 @@ From the Ops Manager VM, use the BOSH CLI client bash command from the **Deploym
   * Remove the clause `BOSH_ALL_PROXY=xxx`
   * Replace the `BOSH_CA_CERT` section with `BOSH_CA_CERT=/var/tempest/workspaces/default/root_ca_certificate` 
 
-#### <a id="1-6-0-management-console-1-1-pks-cli"></a>Run `pks` Commands against the PKS API Server
+#### <a id="management-console-1.6.0-rev2-pks-cli"></a>Run `pks` Commands against the PKS API Server
 
 **Explanation**
 


### PR DESCRIPTION
Created release notes for Management Console 1.6.0-rev.3. This a patch release that is independent of any PKS release. 

Please not merge until we know the GA date for Console 1.6.0-rev.3.

@pspinrad I also grouped all of the console info together, per your suggestion.