### PR TITLE
Removing incorrect and misleading 'Binding'

### DIFF
--- a/manage-cluster-permissions.html.md.erb
+++ b/manage-cluster-permissions.html.md.erb
@@ -278,7 +278,7 @@ with the following:
       apiGroup: rbac.authorization.k8s.io
     roleRef:
       kind: ROLE-TYPE
-      name: ROLE-OR-CLUSTER-ROLE-BINDING-NAME
+      name: ROLE-OR-CLUSTER-ROLE-NAME
       apiGroup: rbac.authorization.k8s.io
     ```
 


### PR DESCRIPTION
The section in question, roleRef -> name, is referring to the Role or ClusterRole that you are binding with the RoleBinding or ClusterRoleBinding. The word 'BINDING' being in that name makes it look like you are trying to refer to a RoleBinding or ClusterRoleBinding instead, which is incorrect.