### PR TITLE
Fixing a copy-paste

### DIFF
--- a/manage-cluster-permissions.html.md.erb
+++ b/manage-cluster-permissions.html.md.erb
@@ -291,4 +291,4 @@ with the following:
     > **UAA**, you must prepend `NAME-OF-GROUP` with the prefix you configured. For more information, see [UAA](./installing-pks-vsphere.html#uaa) in the _Installing_ topic for your IaaS.
     * `ROLE-TYPE` is the type of role you created in the previous step.
     This must be either `Role` or `ClusterRole`.
-    * `ROLE-OR-CLUSTER-ROLE-NAME` is the name of the `Role` or `ClusterRole` you are creating.
+    * `ROLE-OR-CLUSTER-ROLE-NAME` is the name of the `Role` or `ClusterRole` you are binding the Group to.


### PR DESCRIPTION
The sentence was obviously copy/pasted from above and is not correct. In the example we are not creating a Role or a ClusterRole, we are creating a RoleBinding or a ClusterRoleBinding and using it to bind a Role or ClusterRole to a Group.