### PR TITLE
add specfic LB permission

### DIFF
--- a/azure-managed-identities.html.md.erb
+++ b/azure-managed-identities.html.md.erb
@@ -33,6 +33,7 @@ Perform the following steps to create the managed identity for the master nodes:
         "Description":  "Permissions for PKS master",
         "Actions":  [
             "Microsoft.Network/*",
+            "Microsoft.Network/loadBalancers/read",
             "Microsoft.Compute/disks/*",
             "Microsoft.Compute/virtualMachines/write",
             "Microsoft.Compute/virtualMachines/read",
@@ -48,7 +49,9 @@ Perform the following steps to create the managed identity for the master nodes:
 
         ],
         "AssignableScopes":  [
-          "/subscriptions/SUBSCRIPTION-ID/resourceGroups/RESOURCE-GROUP"
+          "/subscriptions/SUBSCRIPTION-ID/resourceGroups/RESOURCE-GROUP",
+          "/subscriptions/SUBSCRIPTION-ID/resourceGroups/RESOURCE-GROUP/providers/Microsoft.Network"
+
         ]
     }
     ```


### PR DESCRIPTION
I needed to add specific LB read permissions as above otherwise exposing a K8s service of type LB failed with:
4m52s Warning SyncLoadBalancerFailed service/nginx-lbsvc Error syncing load balancer: failed to ensure load balancer: network.LoadBalancersClient#List: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailed" Message="The client 'redacted' with object id 'dredacted' does not have authorization to perform action 'Microsoft.Network/loadBalancers/read' over scope '/subscriptions/redacted/resourceGroups/redacted/providers/Microsoft.Network' or the scope is invalid. If access was recently granted, please refresh your credentials."