### PR TITLE
Change get-credentials help message

### DIFF
--- a/cli/index.html.md.erb
+++ b/cli/index.html.md.erb
@@ -255,6 +255,8 @@ Allows you to connect to a cluster and use kubectl
 
 Run this command in order to update a kubeconfig file so you can access the cluster through kubectl
 
+If OIDC is enabled and is not SSO, the password could also be set through environment variable: `PKS_USER_PASSWORD`
+	
 Use the `--sso` flag if PKS tile is configured with SAML
 ```
 pks get-credentials <cluster-name> [flags]


### PR DESCRIPTION
Add information about `PKS_USER_PASSWORD` environment variable when using get-credentials command