### PR TITLE
Update k8s-profiles-encrypt-etcd.html.md.erb

### DIFF
--- a/k8s-profiles-encrypt-etcd.html.md.erb
+++ b/k8s-profiles-encrypt-etcd.html.md.erb
@@ -107,12 +107,12 @@ You can check this encryption by storing and retrieving a new secret:
 
 	For example, if you SSH into your master node and with admin privileges you could run the following command to get the secret and view it. 
   <pre class="terminal">
-	ETCDCTL_API=3 /var/vcap/packages/etcdctl/etcdctl --endpoints https://master-0.etcd.cfcr.internal:2379 --cert /var/vcap/jobs/etcd/config/etcdctl.crt --key /var/vcap/jobs/etcd/config/etcdctl.key --cacert /var/vcap/jobs/etcd/config/etcdctl-ca.crt get /registry/secrets/default/secret1
+	ETCDCTL_API=3 /var/vcap/jobs/etcd/bin/etcdctl get /registry/secrets/default/secret1
 	</pre>
 
 1. Verify the stored secret is prefixed with k8s:enc:aescbc:v1: which indicates the aescbc provider has encrypted the resulting data.
   <pre class="terminal">
-	master/3f9c5ca9-a2b1-469c-9007-6fdd0844a5ec:/var/vcap/bosh_ssh/bosh_2f4aaa514474422# ETCDCTL_API=3 /var/vcap/packages/etcdctl/etcdctl --endpoints https://master-0.etcd.cfcr.internal:2379 --cert /var/vcap/jobs/etcd/config/etcdctl.crt --key /var/vcap/jobs/etcd/config/etcdctl.key --cacert /var/vcap/jobs/etcd/config/etcdctl-ca.crt get /registry/secrets/default/secret1
+	master/3f9c5ca9-a2b1-469c-9007-6fdd0844a5ec:/var/vcap/bosh_ssh/bosh_2f4aaa514474422# ETCDCTL_API=3 /var/vcap/jobs/etcd/bin/etcdctl get /registry/secrets/default/secret1
 
 	/registry/secrets/default/secret1
 	k8s:enc:aescbc:v1:key1:����@�8�����A������2cM7������uL�/


### PR DESCRIPTION
Update the etcdctl cert path inside `k8s-profiles-encrypt-etcd.html.md.erb`
The cert and key paths are changed `/var/vcap/jobs/etcd/config/etcdctl-root.crt`, `/var/vcap/jobs/etcd/config/etcdctl-root.key`
Use the `/var/vcap/jobs/etcd/bin/etcdctl` script so that customer doesn't have to specify the path