### PR TITLE
Update gcp LB doc

### DIFF
--- a/gcp-api-load-balancer.html.md.erb
+++ b/gcp-api-load-balancer.html.md.erb
@@ -21,7 +21,6 @@ To create a GCP load balancer for the <%= vars.control_plane %>, do the followin
 1. [Create a Firewall Rule](#firewall-rule)
 1. [Create a DNS Entry](#dns-entry)
 1. [Install <%= vars.product_short %>](#install)
-1. [Create a Network Tag for the Firewall Rule](#tag)
 
 ## <a id='create-lb'></a>Create a Load Balancer
 
@@ -83,7 +82,7 @@ To create a firewall rule that allows traffic between the load balancer and the 
    * Under **Direction of traffic**, select **Ingress**.
    * Under **Action on match**, select **Allow**.
    * Under **Targets**, select **Specified target tags**.
-   * Under **Target tags**, enter `tkgi-api`.
+   * Under **Target tags**, enter the same name that you used for Load Balancer, for example `tkgi-api`. Because later when deploying <%= vars.control_plane %> in Opsmanager, it will add Load Balancer name as tag to the <%= vars.control_plane %> VM, and this Firewall rule will be applied to the  <%= vars.control_plane %> VM.
    * Under **Source filter**, select **IP ranges**.
    * Under **Source IP ranges**, enter `0.0.0.0/0`.
    * Under **Protocols and ports**, select **Specified protocols and ports** and enter `tcp:8443,9021`.
@@ -119,17 +118,3 @@ as your <%= vars.control_plane %> load balancer hostname.
 ## <a id='install'></a>Install <%= vars.product_short %>
 
 Follow the instructions in [Installing <%= vars.product_short %> on GCP](installing-gcp.html) to deploy <%= vars.product_short %>.
-After you finish installing <%= vars.product_short %>, continue to the [Create a Network Tag for the Firewall Rule](#tag) section below to complete the <%= vars.control_plane %> load balancer configuration.
-
-## <a id='tag'></a>Create a Network Tag for the Firewall Rule
-
-To apply the firewall rule to the VM or VMs hosting the <%= vars.control_plane %>, the VM must have the `tkgi-api` tag in GCP. Do the following:
-
-1. From the GCP console, navigate to **Compute Engine** > **VM instances**.
-1. Locate your <%= vars.control_plane %> VM, or VMs.
-To locate this VM, you can search for the `pivotal-container-service` job label on the **VM instances** page.
-1. Click the name of the VM to open the **VM instance details** menu.
-1. Click **Edit**.
-1. Verify that the **Network tags** field contains the `tkgi-api` tag. Add the tag if it does not appear in the field.
-1. Repeat the preceding steps for your other VMs with the `pivotal-container-service` job label and apply the `tkgi-api` tag to each.
-1. Scroll to the bottom of the screen and click **Save**.


### PR DESCRIPTION
Which other branches should this be merged with (if any)? 1.8 to 1.10
No need to add tag manually to TKGI API VM since bosh will do that if LB is input in Resource Config when deploying TKGI tile, and apply the firewall rule to the VM automatically, also add TKGI-API VM to the target pool automatically.
