### PR TITLE
specified CAs which must be included

### DIFF
--- a/vsphere-nsxt-om-config.html.md.erb
+++ b/vsphere-nsxt-om-config.html.md.erb
@@ -248,7 +248,7 @@ To create Availability Zones in the BOSH Director tile:
 
 1. Select **Security**.
 
-1. In **Trusted Certificates**, enter a custom certificate authority (CA) certificate to insert into your organization's certificate trust chain. 
+1. In **Trusted Certificates**, enter a custom certificate authority (CA) certificate to insert into your organization's certificate trust chain. If using self-signed CAs for your components (NSX-T, vCenter), you need to add every CA of every component your deployment may contact.
 This feature allows all BOSH-deployed components in your deployment to trust a custom root certificate.<br/><br/> 
 
     If you are using a private Docker registry, such as VMware Harbor, use this field to enter the certificate for the registry. See [Integrating Harbor Registry with <%= vars.product_short %>](https://docs.pivotal.io/partners/vmware-harbor/integrating-pks.html) for details.


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
I guess all branches could need that change.

Background:
I spent a whole day of troubleshooting my environment because of this. Which is important here is, that you also need to add NSX-T CAs to this bundle. Also this field takes a PEM-Bundle and not only a single CA-Certificate.

In other steps of the installations you explicitly configure the NSX-T Certificates but this is NOT enough to let BOSH work properly. You also MUST specify the certificate here. Because of the explicit configuration in other steps one is not directly tempted to add the cert at that place.