### PR TITLE
Update TKGI 1.10 location of Windows pause image

### DIFF
--- a/windows-pause-internetless.html.md.erb
+++ b/windows-pause-internetless.html.md.erb
@@ -48,13 +48,13 @@ see [Allow push of nondistributable artifacts](https://docs.docker.com/engine/re
 1. To download a Windows container image from the Microsoft Docker registry, run the following command:
 
     ```
-    docker pull mcr.microsoft.com/k8s/core/pause:1.3.0
+    docker pull mcr.microsoft.com/oss/kubernetes/pause:1.3.0
     ```
 
 1. To tag the Windows container image, run the following command:
 
     ```
-    docker tag mcr.microsoft.com/k8s/core/pause:1.3.0  REGISTRY-ROOT/windows/pause:1.3.0
+    docker tag mcr.microsoft.com/oss/kubernetes/pause:1.3.0  REGISTRY-ROOT/windows/pause:1.3.0
     ```
 
     Where `REGISTRY-ROOT` is your private registry's URI.   


### PR DESCRIPTION
Microsoft moved the location of the Windows pause image and this PR updates the relevant docs in 1.10. 

This patch will also need a backport to the 1.9 branch. I'll submit a [separate PR](#1322) for that.