### PR TITLE
Fix typo in Velero documentation

### DIFF
--- a/velero-install.html.md.erb
+++ b/velero-install.html.md.erb
@@ -518,7 +518,7 @@ The instructions use Harbor.
 5. After installing, configure the Restic post-installation settings:
     * Customize the Restic helper container and make it the [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
     for the pod during the restore process.
-    You can do this by creating a configmap and applying it in the Velero namespace, for example `kubect apply -f restic-cm.yaml -n velero`.
+    You can do this by creating a configmap and applying it in the Velero namespace, for example `kubectl apply -f restic-cm.yaml -n velero`.
     Download the example configmap [restic-cm.yaml](https://github.com/pivotal-cf/docs-pks/tree/1.9/demos/velero-restic/) provided for this purpose.
     * Modify the host path by editing the Restic daemonset manifest. Replace `/var/lib/kubelet/pods` with `/var/vcap/data/kubelet/pods`.
     Verify that the Restic pods are running.


### PR DESCRIPTION
While running through the 1.11 branch instructions, we ran into a typo in one of the `kubectl` commands in the Velero docs.  Fixed in this commit and should be merged in all branches.
