### PR TITLE
Typos in page Creating NSX-T Objects

### DIFF
--- a/nsxt-create-objects.html.md.erb
+++ b/nsxt-create-objects.html.md.erb
@@ -22,7 +22,7 @@ Complete the following instructions to create the required NSX-T network objects
 
 ##<a id='create-nodes-ipb'></a> Create the Nodes IP Block
 
-1. In NSX Manager, go to **Advanced Networking & Security** > **Networking > IPAM**.
+1. In NSX-T Manager, go to **Advanced Networking & Security** > **Networking > IPAM**.
 
 1. Add a new IP Block for Kubernetes Nodes.
    For example:
@@ -38,7 +38,7 @@ Complete the following instructions to create the required NSX-T network objects
 
 ##<a id='create-pods-ipb'></a> Create the Pods IP Block
 
-1. In NSX Manager, go to **Advanced Networking & Security** > **Networking > IPAM**.
+1. In NSX-T Manager, go to **Advanced Networking & Security** > **Networking > IPAM**.
 
 1. Add a new IP Block for Pods. For example:
    * **Name**: TKGI-PODS-IP-BLOCK
@@ -53,7 +53,7 @@ Complete the following instructions to create the required NSX-T network objects
 
 ##<a id='create-float-ipp'></a> Create Floating IP Pool
 
-1. In NSX Manager, go to **Advanced Networking & Security** > **Inventory > Groups > IP Pool**.
+1. In NSX-T Manager, go to **Advanced Networking & Security** > **Inventory > Groups > IP Pool**.
   <img src="images/nsxt/nsx-objects/create-float-ipp-01.png">
 
 1. Add a new Floating IP Pool. For example:
@@ -63,7 +63,7 @@ Complete the following instructions to create the required NSX-T network objects
    * **CIDR**: 10.40.14.0/24
   <img src="images/nsxt/nsx-objects/create-float-ipp-02.png">
 
-1. Verify creation of the Nodes IP Block.
+1. Verify creation of the Floating IP Pool.
   <img src="images/nsxt/nsx-objects/create-float-ipp-03.png">
 
 1. Get the UUID of the Floating IP Pool object. You use this UUID when you install <%= vars.product_short %> with NSX-T.


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
These issues are present since PKS 1.3.

There is another issue with **Create the Nodes IP Block**:
Point 2. says **name** is `NODES-IP-BLOCK` and **CIDR** is `192.168.0.0/16`, 
but the screenshot is for **name** `nodes-ip-block` (in lower case) and **CIDR** `40.0.0.0/16`.
Then point 3 shows a screenshot for **name** `PKS-POD-IP-BLOCK` (which is for pods, not nodes) and **CIDR** `172.16.0.0/16`
Finally point 4 shows a screenshot for yet another **name** `PKS-NOD...` and initial **CIDR** is `192.168.0.0/16` (and `PKS-POD-IP-BLOCK` which is incorrect for next section).
Because the next section uses "TKGI" as prefix (as opposed to "PKS"), maybe this section should too.

The next section **Create the Pods IP Block** has similar inconsistencies:
Point 2. says **name** `TKGI-PODS-IP-BLOCK`, 
but the screenshot shows **name** `PKS-PODS-IP-BLOCK`.
Point 3 shows a screenshot with two objects: **name** `nodes-ip-block` and **name** `pods-ip-block`
Finally, point 4 shows a screenshot with **name** `PKS-PODS-IP-BLOCK`.

Same again in next section **Create Floating IP Pool**:
Point 2. says **name** `TKGI-FLOATING-IP-POOL`, 
but the screenshot shows **name** `PKS-FLOATING-IP-POOL`.
Point 3 shows a screenshot with **name** `PKS-FLOATING-IP-POOL`.

I acknowledge that these are minor issues, but I think they should be fixed to avoid confusing the reader.