### PR TITLE
Update nsxt-mgmt-lb.html.md.erb

### DIFF
--- a/nsxt-mgmt-lb.html.md.erb
+++ b/nsxt-mgmt-lb.html.md.erb
@@ -15,7 +15,7 @@ The diagram below shows an external load balancer fronting the NSX-T Manager nod
 
   <img src="images/nsxt/mgmt-cluster/mgmt-cluster-01.png" alt="NSX Management Cluster with Load Balancer" width="425">
 
-<p class="note"><strong>Note:</strong> The load balancer VIP load balances traffic to all NSX-T Manager instances in round robin fashion. A Cluster HA VIP, on the other hand, only sends traffic one of the NSX-T Manager instances that is mapped to the Cluster IP VIP; the other NSX-T manager instances do not receive any traffic.</p>
+<p class="note"><strong>Note:</strong> The load balancer VIP load balances traffic to all NSX-T Manager instances in round robin fashion. A Cluster HA VIP, on the other hand, only sends traffic one of the NSX-T Manager instances that is mapped to the Cluster IP VIP; the other NSX-T Manager instances do not receive any traffic.</p>
 
 For scalability, deploy a load balancer in front of the NSX-T Manager nodes. When provisioning the load balancer, you configure a virtual server on the load balancer, and associate a virtual IP address with the virtual server. This load balancer VIP can be used as the entry-point for TKGI- and NCP-related API requests on the NSX-T Control Plane. The virtual server includes a member pool where all NSX-T Management Cluster nodes belong. Additionally, health monitoring is enabled for the member pool to quickly and efficiently address potential node failures detected among the NSX-T Management Cluster.
 

--- a/nsxt-mgmt-lb.html.md.erb
+++ b/nsxt-mgmt-lb.html.md.erb
@@ -9,15 +9,15 @@ This topic describes how to deploy a load balancer for the NSX-T Management Clus
 
 NSX-T provides a converged management and control plane that is referred to as the **NSX-T Management Cluster**. The architecture delivers high availability of the NSX-T Manager node, reduces the likelihood of operation failures of NSX-T, and provides API and UI clients with multiple endpoints or a single VIP for high availability.
 
-While using a VIP to access the NSX-T Management layer provides high-availability, it does not balance the workload. To avoid overloading a single NSX-T Manager, as may be the case when [HA VIP addressing](https://docs.vmware.com/en/VMware-Validated-Design/5.0.1/com.vmware.vvd.sddc-nsxt-domain-deploy.doc/GUID-B7019BCE-4FA1-40BB-8DC2-EE47967A47F1.html?hWord=N4IghgNiBcIGoEkAKIC+Q) is used, an NSX-T load balancer can be provisioned to allow NCP and other components orchestrated by <%= vars.product_short %> to distribute load efficiently among NSX Manager nodes.
+While using a VIP to access the NSX-T Management layer provides high-availability, it does not balance the workload. To avoid overloading a single NSX-T Manager, as may be the case when [HA VIP addressing](https://docs.vmware.com/en/VMware-Validated-Design/5.0.1/com.vmware.vvd.sddc-nsxt-domain-deploy.doc/GUID-B7019BCE-4FA1-40BB-8DC2-EE47967A47F1.html?hWord=N4IghgNiBcIGoEkAKIC+Q) is used, an NSX-T load balancer can be provisioned to allow NCP and other components orchestrated by <%= vars.product_short %> to distribute load efficiently among NSX-T Manager nodes.
 
-The diagram below shows an external load balancer fronting the NSX Manager nodes. The load balancer is deployed within the NSX-T environment and intercepts requests to the NSX-T Management Cluster. The load balancer selects one of the NSX-T Manager nodes to handle the request and rewrites the destination IP address to reflect the selection.
+The diagram below shows an external load balancer fronting the NSX-T Manager nodes. The load balancer is deployed within the NSX-T environment and intercepts requests to the NSX-T Management Cluster. The load balancer selects one of the NSX-T Manager nodes to handle the request and rewrites the destination IP address to reflect the selection.
 
   <img src="images/nsxt/mgmt-cluster/mgmt-cluster-01.png" alt="NSX Management Cluster with Load Balancer" width="425">
 
 <p class="note"><strong>Note:</strong> The load balancer VIP load balances traffic to all NSX-T Manager instances in round robin fashion. A Cluster HA VIP, on the other hand, only sends traffic one of the NSX-T Manager instances that is mapped to the Cluster IP VIP; the other NSX-T manager instances do not receive any traffic.</p>
 
-For scalability, deploy a load balancer in front of the NSX-T Manager nodes. When provisioning the load balancer, you configure a virtual server on the load balancer, and associate a virtual IP address with the virtual server. This load balancer VIP can be used as the entry-point for PKS- and NCP-related API requests on the NSX-T Control Plane. The virtual server includes a member pool where all NSX-T Management Cluster nodes belong. Additionally, health monitoring is enabled for the member pool to quickly and efficiently address potential node failures detected among the NSX-T Management Cluster.
+For scalability, deploy a load balancer in front of the NSX-T Manager nodes. When provisioning the load balancer, you configure a virtual server on the load balancer, and associate a virtual IP address with the virtual server. This load balancer VIP can be used as the entry-point for TKGI- and NCP-related API requests on the NSX-T Control Plane. The virtual server includes a member pool where all NSX-T Management Cluster nodes belong. Additionally, health monitoring is enabled for the member pool to quickly and efficiently address potential node failures detected among the NSX-T Management Cluster.
 
 ##<a id='provision'></a> Provision the NSX-T Load Balancer for the Management Cluster
 
@@ -43,7 +43,7 @@ Add and configure a new logical switch for the load balancer.
 
 ###<a id='s3'></a> Step 3: Configure a Tier-1 Logical Router
 
-Configure a new Tier-1 Router in Active-Standby mode. Create the Tier-1 Router on the same Edge Cluster where the Tier-0 Router that provides external connectivity to vCenter and NSX Manager is located.
+Configure a new Tier-1 Router in Active-Standby mode. Create the Tier-1 Router on the same Edge Cluster where the Tier-0 Router that provides external connectivity to vCenter and NSX-T Manager is located.
 
 - Select **Routers**.
 - Click **Add** > **Tier-1 Router**.
@@ -78,7 +78,7 @@ Verify successful creation and configuration of the logical switch and router.
 
 Create a new small-size Load Balancer and attach it to the Tier1 router previously created.
 
-<p class="note"><strong>Note</strong>: The small-size VM is suitable for the NSX Management Cluster load balancer. Make sure you have enough Edge Cluster resources to provision a small load balancer.</p>
+<p class="note"><strong>Note</strong>: The small-size LB is suitable for the NSX-T Management Cluster load balancer. Make sure you have enough Edge Cluster resources to provision a small load balancer.</p>
 
 - Select **Load Balancers**.
 - Click **Add**.
@@ -130,13 +130,13 @@ Configure **General Properties** for the server pool:
 Configure **SNAT Translation** for the server pool:
 
 - **Translation Mode**: IP List
-- **IP address**: Enter the Virtual Switch IP (VIP) address here, for example `10.40.14.250`.
+- **IP address**: Enter the Virtual Server IP (VIP) address here, for example `10.40.14.250`.
 - Click **Next**.
 
 Configure **Pool Members** for the server pool:
 
 - **Membership Type**: Static.
-- **Static Membership**: Add all 3 NSX Managers as members by entering the node name, IP address, and port (443) for each node.
+- **Static Membership**: Add all 3 NSX-T Managers as members by entering the node name, IP address, and port (443) for each node.
 - Click **Next**.
 
 Configure **Health Monitors**:
@@ -151,7 +151,7 @@ Configure **Load Balancing Profiles** for the load balancer:
 - **Persistence Profile** > **Source IP**: Select **default-source-ip-lb-persistence-profile**
 - Click **Finish**.
 
-<p class="note"><strong>Note:</strong> If a proxy is used between the NSX Management Cluster and the PKS Management Plane, do not configure a persistence profile.</p>
+<p class="note"><strong>Note:</strong> If a proxy is used between the NSX-T Management Cluster and the TKGI Management Plane, do not configure a persistence profile.</p>
 
 ###<a id='s9'></a> Step 9: Attach the Virtual Server to the Load Balancer
 
@@ -174,7 +174,7 @@ Once the load balancer is configured, verify it by doing the following:
 
 ###<a id='s11'></a> Step 11: Create an Active Health Monitor (HM)
 
-Create a new Active Health Monitor (HM) for NSX Management Cluster members using the NSX-T Health Check protocol.
+Create a new Active Health Monitor (HM) for NSX-T Management Cluster members using the NSX-T Health Check protocol.
 
 - Select **Load Balancers** > **Server Pools**.
 - Select the server pool you created (for example, **NSX-T-MGRS-SRV-POOL**). 
@@ -236,7 +236,7 @@ Create the following SNAT rule on the Tier-0 Router:
 
 - Verify configuration of the SNAT rule and server pool health:
 
-###<a id='s13'></a> Step 13: Verify that NSX Manager Traffic Is Load Balanced
+###<a id='s13'></a> Step 13: Verify that NSX-T Manager Traffic Is Load Balanced
 
 Verify the load balancer and that traffic is load balanced.
 
@@ -245,7 +245,7 @@ Verify the load balancer and that traffic is load balanced.
 - Confirm that the status of the Server Pool is Up.
 - Open an HTTPS session using multiple browser clients and confirm that traffic is load-balanced across different NSX-T Managers:
 
-You can use the NSX API to validate that secure HTTP requests against the new VIP address are associated with the load balancer's Virtual Server. Relying on the SuperUser Principal Identity created as part of PKS provisioning steps, you can cURL the NSX Management Cluster using the standard HA-VIP address or the newly-provisioned virtual server VIP. For example:
+You can use the NSX-T API to validate that secure HTTP requests against the new VIP address are associated with the load balancer's Virtual Server. Relying on the SuperUser Principal Identity created as part of TKGI provisioning steps, you can cURL the NSX-T Management Cluster using the standard HA-VIP address or the newly-provisioned virtual server VIP. For example:
 
 Before load balancer provisioning is completed:
 
@@ -259,6 +259,6 @@ After load balancer provisioning is completed:
 curl -k -X GET "https://91.0.0.1/api/v1/trust-management/principal-identities" --cert $(pwd)/pks-nsx-t-superuser.crt --key $(pwd)/pks-nsx-t-superuser.key
 ```
 
-Key behavioral differences among the two API calls is the fact that the call toward the Virtual Server VIP will effectively Load Balance requests among the NSX-T Server Pool members. On the other hand, the call made toward the HA VIP address would ALWAYS select the same member (the Active Member) of the NSX Management Cluster.
+Key behavioral differences among the two API calls is the fact that the call toward the Virtual Server VIP will effectively load balance requests among the NSX-T Server Pool members. On the other hand, the call made toward the HA VIP address would ALWAYS select the same member (the Active Member) of the NSX-T Management Cluster.
 
-Residual configuration step would be to change PKS Tile configuration for NSX-Manager IP Address to use the newly-provisioned Virtual IP Address. This configuration will enable any component internal to PKS (NCP, NSX OSB Proxy, BOSH CPI, etc.) to use the new Load Balancer functionality.
+Residual configuration step would be to change TKGI Tile configuration for NSX-T Manager IP Address to use the newly-provisioned Virtual IP Address. This configuration will enable any component internal to TKGI (NCP, NSX OSB Proxy, BOSH CPI, etc.) to use the new Load Balancer functionality.


### PR DESCRIPTION
NSX -> NSX-T
PKT -> TKGI
I don't think "load balance" as a verb should be capitalised, since "load balancer" as a noun isn't.
"small-size VM" -> "small-size LB" (the NSX-T Load Balancer is not a VM)
The "VIP" we refer to here belongs to the Virtual Server

Which other branches should this be merged with (if any)?
Since 1.8