### PR TITLE
Fix redis-slave not found error

### DIFF
--- a/demos/guestbook-app/frontend-deployment.yaml
+++ b/demos/guestbook-app/frontend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v4
+        image: gcr.io/google-samples/gb-frontend:v5
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
The redis-slave was renamed to redis-follower https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/commit/abbb383b6c58e24b50b2c55fd14926e8a0b1026e
