### PR TITLE
Updated workaround for Wavefront namespace issue in 1.22

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -437,6 +437,8 @@ This happens because of a `wavefront-proxy-errand`.
 
 When you install the Wavefront operator, specify a custom namespace rather than the default `observability-system` namespace.
 
+If the Wavefront operator is already installed in the `observability-system` namespace, see [KB 405433](https://knowledge.broadcom.com/external/article/405433) for instructions so that you do not encounter this issue during cluster upgrades.
+
 <hr>
 
 #### <a id="1-22-0-no-upgrade-ova"></a>Upgrade to TKGI v1.22 fails from the TKGI MC v1.21 OVA

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -437,7 +437,7 @@ This happens because of a `wavefront-proxy-errand`.
 
 When you install the Wavefront operator, specify a custom namespace rather than the default `observability-system` namespace.
 
-If the Wavefront operator is already installed in the `observability-system` namespace, see [KB 405433](https://knowledge.broadcom.com/external/article/405433) for instructions so that you do not encounter this issue during cluster upgrades.
+If the Wavefront operator is already installed in the `observability-system` namespace, see [KB 405433](https://knowledge.broadcom.com/external/article/405433) for steps to take to avoid encountering this issue during cluster upgrades.
 
 <hr>
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)? 1.20 onwards

https://vmw-jira.broadcom.net/browse/TKGI-8254
